### PR TITLE
[WEBSITE-399][WEBSITE-466] Implemented lookup functionality

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,8 @@ gem 'json-ld', '2.1.0'
 gem 'vcard', '0.2.15'
 
 # Parliament Ruby is a wrapper for the internal Parliament data API
-gem 'parliament-ruby', '0.2.2'
+gem 'parliament-ruby', '0.3.0'
+# gem 'parliament-ruby', git: 'https://github.com/katylouise/parliament-ruby', branch: 'katylouise/website-399_query-parameters'
 
 # Pugin is the front-end component library used by Parliament
 gem 'pugin', git: 'https://github.com/ukparliament/pugin', branch: 'development'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,7 +83,7 @@ GEM
     hamster (3.0.0)
       concurrent-ruby (~> 1.0)
     hashdiff (0.3.2)
-    i18n (0.8.0)
+    i18n (0.8.1)
     json (2.0.3)
     json-ld (2.1.0)
       multi_json (~> 1.11)
@@ -104,7 +104,7 @@ GEM
     nio4r (1.2.1)
     nokogiri (1.7.0.1)
       mini_portile2 (~> 2.1.0)
-    parliament-ruby (0.2.2)
+    parliament-ruby (0.3.0)
       grom (~> 0.3.5)
     parser (2.4.0.0)
       ast (~> 2.2)
@@ -230,7 +230,7 @@ DEPENDENCIES
   foreman
   haml (= 4.0.7)
   json-ld (= 2.1.0)
-  parliament-ruby (= 0.2.2)
+  parliament-ruby (= 0.3.0)
   passenger
   pugin!
   rails (= 5.0.1)

--- a/app/controllers/constituencies_controller.rb
+++ b/app/controllers/constituencies_controller.rb
@@ -3,6 +3,15 @@ class ConstituenciesController < ApplicationController
     @constituencies = Parliament::Request.new.constituencies.get
   end
 
+  def lookup
+    source = params[:source]
+    id = params[:id]
+
+    @constituency = Parliament::Request.new.constituencies.lookup.get(params: { source: source, id: id }).first
+
+    redirect_to constituency_path(@constituency.graph_id)
+  end
+
   def show
     constituency_id = params[:constituency_id]
     data = Parliament::Request.new.constituencies(constituency_id).get

--- a/app/controllers/houses_controller.rb
+++ b/app/controllers/houses_controller.rb
@@ -3,6 +3,15 @@ class HousesController < ApplicationController
     @houses = Parliament::Request.new.houses.get
   end
 
+  def lookup
+    source = params[:source]
+    id = params[:id]
+
+    @house = Parliament::Request.new.houses.lookup.get(params: { source: source, id: id }).first
+
+    redirect_to house_path(@house.graph_id)
+  end
+
   def show
     house_id = params[:house_id]
 

--- a/app/controllers/parties_controller.rb
+++ b/app/controllers/parties_controller.rb
@@ -3,6 +3,15 @@ class PartiesController < ApplicationController
     @parties = Parliament::Request.new.parties.get
   end
 
+  def lookup
+    source = params[:source]
+    id = params[:id]
+
+    @party = Parliament::Request.new.parties.lookup.get(params: { source: source, id: id }).first
+
+    redirect_to party_path(@party.graph_id)
+  end
+
   def current
     @parties = Parliament::Request.new.parties.current.get
   end

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -3,6 +3,15 @@ class PeopleController < ApplicationController
     @people = Parliament::Request.new.people.get
   end
 
+  def lookup
+    source = params[:source]
+    id = params[:id]
+
+    @person = Parliament::Request.new.people.lookup.get(params: { source: source, id: id }).first
+
+    redirect_to person_path(@person.graph_id)
+  end
+
   def show
     person_id = params[:person_id]
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,6 +25,7 @@ Rails.application.routes.draw do
   # /people (multiple 'people' scope)
   scope '/people', as: 'people' do
     get '/', to: 'people#index'
+    get 'lookup', to: 'people#lookup'
 
     listable('people#letters')
 
@@ -79,6 +80,7 @@ Rails.application.routes.draw do
   scope '/parties', as: 'parties' do
     get '/',        to: 'parties#index'
     get '/current', to: 'parties#current'
+    get '/lookup', to: 'parties#lookup'
 
     listable('parties#letters')
   end
@@ -112,6 +114,7 @@ Rails.application.routes.draw do
   # /constituencies (multiple 'constituencies' scope)
   scope '/constituencies', as: 'constituencies' do
     get '/', to: 'constituencies#index'
+    get '/lookup', to: 'constituencies#lookup'
 
     listable('constituencies#letters')
 
@@ -161,6 +164,7 @@ Rails.application.routes.draw do
   # /houses (multiple 'houses' scope)
   scope '/houses', as: 'houses' do
     get '/', to: 'houses#index'
+    get '/lookup', to: 'houses#lookup'
   end
 
   # /houses (single 'house' scope)

--- a/spec/controllers/constituencies_controller_spec.rb
+++ b/spec/controllers/constituencies_controller_spec.rb
@@ -23,6 +23,20 @@ RSpec.describe ConstituenciesController, vcr: true do
     end
   end
 
+  describe 'GET lookup' do
+    before(:each) do
+      get :lookup, params: { source: 'mnisId', id: '3274' }
+    end
+
+    it 'should have a response with http status redirect (302)' do
+      expect(response).to have_http_status(302)
+    end
+
+    it 'redirects to constituencies/:id' do
+      expect(response).to redirect_to(constituency_path('95e3953e-a2bf-4ec0-bc57-5d073661f43a'))
+    end
+  end
+
   describe 'GET show' do
     before(:each) do
       get :show, params: { constituency_id: 'f9216185-f3dc-417c-a02e-455faedb2ac2' }

--- a/spec/controllers/houses_controller_spec.rb
+++ b/spec/controllers/houses_controller_spec.rb
@@ -23,6 +23,20 @@ RSpec.describe HousesController, vcr: true do
     end
   end
 
+  describe 'GET lookup' do
+    before(:each) do
+      get :lookup, params: { source: 'mnisId', id: '1' }
+    end
+
+    it 'should have a response with http status redirect (302)' do
+      expect(response).to have_http_status(302)
+    end
+
+    it 'redirects to houses/:id' do
+      expect(response).to redirect_to(house_path('9fc46fca-4a66-4fa9-a4af-d4c2bf1a2703'))
+    end
+  end
+
   describe "GET show" do
     before(:each) do
       get :show, params: {house_id: 'c2d41b82-d4df-4f50-b0f9-f52b84a6a788'}

--- a/spec/controllers/parties_controller_spec.rb
+++ b/spec/controllers/parties_controller_spec.rb
@@ -22,6 +22,20 @@ RSpec.describe PartiesController, vcr: true do
     end
   end
 
+  describe 'GET lookup' do
+    before(:each) do
+      get :lookup, params: { source: 'mnisId', id: '96' }
+    end
+
+    it 'should have a response with http status redirect (302)' do
+      expect(response).to have_http_status(302)
+    end
+
+    it 'redirects to parties/:id' do
+      expect(response).to redirect_to(party_path('9fc46fca-4a66-4fa9-a4af-d4c2bf1a2703'))
+    end
+  end
+
   describe 'GET current' do
     before(:each) do
       get :current

--- a/spec/controllers/people_controller_spec.rb
+++ b/spec/controllers/people_controller_spec.rb
@@ -23,9 +23,23 @@ RSpec.describe PeopleController, vcr: true do
     end
   end
 
+  describe 'GET lookup' do
+    before(:each) do
+      get :lookup, params: { source: 'mnisId', id: '3898' }
+    end
+
+    it 'should have a response with http status redirect (302)' do
+      expect(response).to have_http_status(302)
+    end
+
+    it 'redirects to people/:id' do
+      expect(response).to redirect_to(person_path('581ade57-3805-4a4a-82c9-8d622cb352a4'))
+    end
+  end
+
   describe "GET show" do
     before(:each) do
-      get :show, params: {person_id: '626b57f9-6ef0-475a-ae12-40a44aca7eff'}
+      get :show, params: { person_id: '626b57f9-6ef0-475a-ae12-40a44aca7eff' }
     end
 
     it 'should have a response with http status ok (200)' do

--- a/spec/fixtures/vcr_cassettes/ConstituenciesController/GET_contact_point/assigns_constituency.yml
+++ b/spec/fixtures/vcr_cassettes/ConstituenciesController/GET_contact_point/assigns_constituency.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/constituencies/8d895ffc-c2bf-43d2-b756-95ab3e987919/contact_point.nt
+    uri: http://localhost:3030/constituencies/8d895ffc-c2bf-43d2-b756-95ab3e987919/contact_point
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/ConstituenciesController/GET_contact_point/renders_the_contact_point_template.yml
+++ b/spec/fixtures/vcr_cassettes/ConstituenciesController/GET_contact_point/renders_the_contact_point_template.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/constituencies/8d895ffc-c2bf-43d2-b756-95ab3e987919/contact_point.nt
+    uri: http://localhost:3030/constituencies/8d895ffc-c2bf-43d2-b756-95ab3e987919/contact_point
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/ConstituenciesController/GET_contact_point/should_have_a_response_with_a_http_status_ok_200_.yml
+++ b/spec/fixtures/vcr_cassettes/ConstituenciesController/GET_contact_point/should_have_a_response_with_a_http_status_ok_200_.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/constituencies/8d895ffc-c2bf-43d2-b756-95ab3e987919/contact_point.nt
+    uri: http://localhost:3030/constituencies/8d895ffc-c2bf-43d2-b756-95ab3e987919/contact_point
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/ConstituenciesController/GET_current/assigns_constituencies.yml
+++ b/spec/fixtures/vcr_cassettes/ConstituenciesController/GET_current/assigns_constituencies.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/constituencies/current.nt
+    uri: http://localhost:3030/constituencies/current
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/ConstituenciesController/GET_current/renders_the_current_template.yml
+++ b/spec/fixtures/vcr_cassettes/ConstituenciesController/GET_current/renders_the_current_template.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/constituencies/current.nt
+    uri: http://localhost:3030/constituencies/current
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/ConstituenciesController/GET_current/should_have_a_response_with_http_status_ok_200_.yml
+++ b/spec/fixtures/vcr_cassettes/ConstituenciesController/GET_current/should_have_a_response_with_http_status_ok_200_.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/constituencies/current.nt
+    uri: http://localhost:3030/constituencies/current
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/ConstituenciesController/GET_current_letters/assigns_constituencies.yml
+++ b/spec/fixtures/vcr_cassettes/ConstituenciesController/GET_current_letters/assigns_constituencies.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/constituencies/current/a.nt
+    uri: http://localhost:3030/constituencies/current/a
     body:
       encoding: US-ASCII
       string: ''
@@ -79,6 +79,6 @@ http_interactions:
         <http://id.ukpds.org/5177ccd7-65a9-4223-8ced-9ff8ca45b6fa> <http://id.ukpds.org/schema/constituencyGroupName> "Ashfield" .
         <http://id.ukpds.org/784a6d8e-d60d-4110-9c15-0662d4f2058a> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.ukpds.org/schema/ConstituencyGroup> .
         <http://id.ukpds.org/784a6d8e-d60d-4110-9c15-0662d4f2058a> <http://id.ukpds.org/schema/constituencyGroupName> "Argyll and Bute" .
-    http_version: 
+    http_version:
   recorded_at: Mon, 20 Feb 2017 15:54:55 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/ConstituenciesController/GET_current_letters/renders_the_current_letters_template.yml
+++ b/spec/fixtures/vcr_cassettes/ConstituenciesController/GET_current_letters/renders_the_current_letters_template.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/constituencies/current/a.nt
+    uri: http://localhost:3030/constituencies/current/a
     body:
       encoding: US-ASCII
       string: ''
@@ -79,6 +79,6 @@ http_interactions:
         <http://id.ukpds.org/5177ccd7-65a9-4223-8ced-9ff8ca45b6fa> <http://id.ukpds.org/schema/constituencyGroupName> "Ashfield" .
         <http://id.ukpds.org/784a6d8e-d60d-4110-9c15-0662d4f2058a> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.ukpds.org/schema/ConstituencyGroup> .
         <http://id.ukpds.org/784a6d8e-d60d-4110-9c15-0662d4f2058a> <http://id.ukpds.org/schema/constituencyGroupName> "Argyll and Bute" .
-    http_version: 
+    http_version:
   recorded_at: Mon, 20 Feb 2017 15:54:55 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/ConstituenciesController/GET_current_letters/should_have_a_response_with_http_status_ok_200_.yml
+++ b/spec/fixtures/vcr_cassettes/ConstituenciesController/GET_current_letters/should_have_a_response_with_http_status_ok_200_.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/constituencies/current/a.nt
+    uri: http://localhost:3030/constituencies/current/a
     body:
       encoding: US-ASCII
       string: ''
@@ -79,6 +79,6 @@ http_interactions:
         <http://id.ukpds.org/5177ccd7-65a9-4223-8ced-9ff8ca45b6fa> <http://id.ukpds.org/schema/constituencyGroupName> "Ashfield" .
         <http://id.ukpds.org/784a6d8e-d60d-4110-9c15-0662d4f2058a> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.ukpds.org/schema/ConstituencyGroup> .
         <http://id.ukpds.org/784a6d8e-d60d-4110-9c15-0662d4f2058a> <http://id.ukpds.org/schema/constituencyGroupName> "Argyll and Bute" .
-    http_version: 
+    http_version:
   recorded_at: Mon, 20 Feb 2017 15:54:55 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/ConstituenciesController/GET_current_member/assigns_constituency.yml
+++ b/spec/fixtures/vcr_cassettes/ConstituenciesController/GET_current_member/assigns_constituency.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/constituencies/f9216185-f3dc-417c-a02e-455faedb2ac2/members/current.nt
+    uri: http://localhost:3030/constituencies/f9216185-f3dc-417c-a02e-455faedb2ac2/members/current
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/ConstituenciesController/GET_current_member/renders_the_current_member_template.yml
+++ b/spec/fixtures/vcr_cassettes/ConstituenciesController/GET_current_member/renders_the_current_member_template.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/constituencies/f9216185-f3dc-417c-a02e-455faedb2ac2/members/current.nt
+    uri: http://localhost:3030/constituencies/f9216185-f3dc-417c-a02e-455faedb2ac2/members/current
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/ConstituenciesController/GET_current_member/should_have_a_response_with_a_http_status_ok_200_.yml
+++ b/spec/fixtures/vcr_cassettes/ConstituenciesController/GET_current_member/should_have_a_response_with_a_http_status_ok_200_.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/constituencies/f9216185-f3dc-417c-a02e-455faedb2ac2/members/current.nt
+    uri: http://localhost:3030/constituencies/f9216185-f3dc-417c-a02e-455faedb2ac2/members/current
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/ConstituenciesController/GET_index/assigns_constituencies.yml
+++ b/spec/fixtures/vcr_cassettes/ConstituenciesController/GET_index/assigns_constituencies.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/constituencies.nt
+    uri: http://localhost:3030/constituencies
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/ConstituenciesController/GET_index/renders_the_index_template.yml
+++ b/spec/fixtures/vcr_cassettes/ConstituenciesController/GET_index/renders_the_index_template.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/constituencies.nt
+    uri: http://localhost:3030/constituencies
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/ConstituenciesController/GET_index/should_have_a_response_with_http_status_ok_200_.yml
+++ b/spec/fixtures/vcr_cassettes/ConstituenciesController/GET_index/should_have_a_response_with_http_status_ok_200_.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/constituencies.nt
+    uri: http://localhost:3030/constituencies
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/ConstituenciesController/GET_letters/assigns_constituencies.yml
+++ b/spec/fixtures/vcr_cassettes/ConstituenciesController/GET_letters/assigns_constituencies.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/constituencies/a.nt
+    uri: http://localhost:3030/constituencies/a
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/ConstituenciesController/GET_letters/renders_the_letters_template.yml
+++ b/spec/fixtures/vcr_cassettes/ConstituenciesController/GET_letters/renders_the_letters_template.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/constituencies/a.nt
+    uri: http://localhost:3030/constituencies/a
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/ConstituenciesController/GET_letters/should_have_a_response_with_http_status_ok_200_.yml
+++ b/spec/fixtures/vcr_cassettes/ConstituenciesController/GET_letters/should_have_a_response_with_http_status_ok_200_.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/constituencies/a.nt
+    uri: http://localhost:3030/constituencies/a
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/ConstituenciesController/GET_lookup/redirects_to_constituencies/_id.yml
+++ b/spec/fixtures/vcr_cassettes/ConstituenciesController/GET_lookup/redirects_to_constituencies/_id.yml
@@ -1,0 +1,47 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:3030/constituencies/lookup?id=3274&source=mnisId
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - localhost:3030
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/n-triples; charset=utf-8
+      Etag:
+      - W/"ad5b9013a3db55e710e8d65cd8b82cfb"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 103e9a6b-658c-4f75-a320-6665dbe6d961
+      X-Runtime:
+      - '0.035792'
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: "<http://id.ukpds.org/95e3953e-a2bf-4ec0-bc57-5d073661f43a> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <http://id.ukpds.org/schema/ConstituencyGroup> .\n"
+    http_version: 
+  recorded_at: Wed, 22 Feb 2017 16:27:34 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/ConstituenciesController/GET_lookup/redirects_to_people/_id.yml
+++ b/spec/fixtures/vcr_cassettes/ConstituenciesController/GET_lookup/redirects_to_people/_id.yml
@@ -1,0 +1,47 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:3030/constituencies/lookup?id=3274&source=mnisId
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - localhost:3030
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/n-triples; charset=utf-8
+      Etag:
+      - W/"ad5b9013a3db55e710e8d65cd8b82cfb"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - dbca62a8-9465-4bf9-8f9b-bb907d1c93d6
+      X-Runtime:
+      - '0.044572'
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: "<http://id.ukpds.org/95e3953e-a2bf-4ec0-bc57-5d073661f43a> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <http://id.ukpds.org/schema/ConstituencyGroup> .\n"
+    http_version: 
+  recorded_at: Wed, 22 Feb 2017 16:16:26 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/ConstituenciesController/GET_lookup/should_have_a_response_with_http_status_redirect_302_.yml
+++ b/spec/fixtures/vcr_cassettes/ConstituenciesController/GET_lookup/should_have_a_response_with_http_status_redirect_302_.yml
@@ -1,0 +1,47 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:3030/constituencies/lookup?id=3274&source=mnisId
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - localhost:3030
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/n-triples; charset=utf-8
+      Etag:
+      - W/"ad5b9013a3db55e710e8d65cd8b82cfb"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - e93f8ff9-8148-4ac5-be2d-4846781520da
+      X-Runtime:
+      - '0.033297'
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: "<http://id.ukpds.org/95e3953e-a2bf-4ec0-bc57-5d073661f43a> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <http://id.ukpds.org/schema/ConstituencyGroup> .\n"
+    http_version: 
+  recorded_at: Wed, 22 Feb 2017 16:16:26 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/ConstituenciesController/GET_lookup_by_letters/it_returns_a_single_result/redirects_to_constituencies/_id.yml
+++ b/spec/fixtures/vcr_cassettes/ConstituenciesController/GET_lookup_by_letters/it_returns_a_single_result/redirects_to_constituencies/_id.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/constituencies/arfon.nt
+    uri: http://localhost:3030/constituencies/arfon
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/ConstituenciesController/GET_lookup_by_letters/it_returns_a_single_result/should_have_a_response_with_http_status_redirect_302_.yml
+++ b/spec/fixtures/vcr_cassettes/ConstituenciesController/GET_lookup_by_letters/it_returns_a_single_result/should_have_a_response_with_http_status_redirect_302_.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/constituencies/arfon.nt
+    uri: http://localhost:3030/constituencies/arfon
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/ConstituenciesController/GET_lookup_by_letters/it_returns_multiple_results/redirects_to_constituencies/a-z/hove.yml
+++ b/spec/fixtures/vcr_cassettes/ConstituenciesController/GET_lookup_by_letters/it_returns_multiple_results/redirects_to_constituencies/a-z/hove.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/constituencies/hove.nt
+    uri: http://localhost:3030/constituencies/hove
     body:
       encoding: US-ASCII
       string: ''
@@ -51,6 +51,6 @@ http_interactions:
         <http://id.ukpds.org/0705eb07-3235-4a25-8473-6ef2a741ce64> <http://id.ukpds.org/schema/constituencyGroupName> "Hove" .
         <http://id.ukpds.org/c458dc03-f729-446e-9972-b14b71ad7d9b> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.ukpds.org/schema/ConstituencyGroup> .
         <http://id.ukpds.org/c458dc03-f729-446e-9972-b14b71ad7d9b> <http://id.ukpds.org/schema/constituencyGroupName> "Hove" .
-    http_version: 
+    http_version:
   recorded_at: Mon, 20 Feb 2017 17:19:42 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/ConstituenciesController/GET_lookup_by_letters/it_returns_multiple_results/should_have_a_response_with_http_status_redirect_302_.yml
+++ b/spec/fixtures/vcr_cassettes/ConstituenciesController/GET_lookup_by_letters/it_returns_multiple_results/should_have_a_response_with_http_status_redirect_302_.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/constituencies/hove.nt
+    uri: http://localhost:3030/constituencies/hove
     body:
       encoding: US-ASCII
       string: ''
@@ -51,6 +51,6 @@ http_interactions:
         <http://id.ukpds.org/0705eb07-3235-4a25-8473-6ef2a741ce64> <http://id.ukpds.org/schema/constituencyGroupName> "Hove" .
         <http://id.ukpds.org/c458dc03-f729-446e-9972-b14b71ad7d9b> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.ukpds.org/schema/ConstituencyGroup> .
         <http://id.ukpds.org/c458dc03-f729-446e-9972-b14b71ad7d9b> <http://id.ukpds.org/schema/constituencyGroupName> "Hove" .
-    http_version: 
+    http_version:
   recorded_at: Mon, 20 Feb 2017 17:19:43 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/ConstituenciesController/GET_map/assigns_constituency.yml
+++ b/spec/fixtures/vcr_cassettes/ConstituenciesController/GET_map/assigns_constituency.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/constituencies/f9216185-f3dc-417c-a02e-455faedb2ac2.nt
+    uri: http://localhost:3030/constituencies/f9216185-f3dc-417c-a02e-455faedb2ac2
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/ConstituenciesController/GET_map/renders_the_map_template.yml
+++ b/spec/fixtures/vcr_cassettes/ConstituenciesController/GET_map/renders_the_map_template.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/constituencies/f9216185-f3dc-417c-a02e-455faedb2ac2.nt
+    uri: http://localhost:3030/constituencies/f9216185-f3dc-417c-a02e-455faedb2ac2
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/ConstituenciesController/GET_map/should_have_a_response_with_a_http_status_ok_200_.yml
+++ b/spec/fixtures/vcr_cassettes/ConstituenciesController/GET_map/should_have_a_response_with_a_http_status_ok_200_.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/constituencies/f9216185-f3dc-417c-a02e-455faedb2ac2.nt
+    uri: http://localhost:3030/constituencies/f9216185-f3dc-417c-a02e-455faedb2ac2
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/ConstituenciesController/GET_members/assigns_constituency.yml
+++ b/spec/fixtures/vcr_cassettes/ConstituenciesController/GET_members/assigns_constituency.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/constituencies/f9216185-f3dc-417c-a02e-455faedb2ac2/members.nt
+    uri: http://localhost:3030/constituencies/f9216185-f3dc-417c-a02e-455faedb2ac2/members
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/ConstituenciesController/GET_members/renders_the_members_template.yml
+++ b/spec/fixtures/vcr_cassettes/ConstituenciesController/GET_members/renders_the_members_template.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/constituencies/f9216185-f3dc-417c-a02e-455faedb2ac2/members.nt
+    uri: http://localhost:3030/constituencies/f9216185-f3dc-417c-a02e-455faedb2ac2/members
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/ConstituenciesController/GET_members/should_have_a_response_with_a_http_status_ok_200_.yml
+++ b/spec/fixtures/vcr_cassettes/ConstituenciesController/GET_members/should_have_a_response_with_a_http_status_ok_200_.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/constituencies/f9216185-f3dc-417c-a02e-455faedb2ac2/members.nt
+    uri: http://localhost:3030/constituencies/f9216185-f3dc-417c-a02e-455faedb2ac2/members
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/ConstituenciesController/GET_show/assigns_constituency.yml
+++ b/spec/fixtures/vcr_cassettes/ConstituenciesController/GET_show/assigns_constituency.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/constituencies/f9216185-f3dc-417c-a02e-455faedb2ac2.nt
+    uri: http://localhost:3030/constituencies/f9216185-f3dc-417c-a02e-455faedb2ac2
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/ConstituenciesController/GET_show/renders_the_show_template.yml
+++ b/spec/fixtures/vcr_cassettes/ConstituenciesController/GET_show/renders_the_show_template.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/constituencies/f9216185-f3dc-417c-a02e-455faedb2ac2.nt
+    uri: http://localhost:3030/constituencies/f9216185-f3dc-417c-a02e-455faedb2ac2
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/ConstituenciesController/GET_show/should_have_a_response_with_a_http_status_ok_200_.yml
+++ b/spec/fixtures/vcr_cassettes/ConstituenciesController/GET_show/should_have_a_response_with_a_http_status_ok_200_.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/constituencies/f9216185-f3dc-417c-a02e-455faedb2ac2.nt
+    uri: http://localhost:3030/constituencies/f9216185-f3dc-417c-a02e-455faedb2ac2
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/ContactPointsController/GET_index/assigns_contact_points.yml
+++ b/spec/fixtures/vcr_cassettes/ContactPointsController/GET_index/assigns_contact_points.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/contact_points.nt
+    uri: http://localhost:3030/contact_points
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/ContactPointsController/GET_index/renders_the_index_template.yml
+++ b/spec/fixtures/vcr_cassettes/ContactPointsController/GET_index/renders_the_index_template.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/contact_points.nt
+    uri: http://localhost:3030/contact_points
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/ContactPointsController/GET_index/should_have_a_response_with_http_status_ok_200_.yml
+++ b/spec/fixtures/vcr_cassettes/ContactPointsController/GET_index/should_have_a_response_with_http_status_ok_200_.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/contact_points.nt
+    uri: http://localhost:3030/contact_points
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/ContactPointsController/GET_show/assigns_contact.yml
+++ b/spec/fixtures/vcr_cassettes/ContactPointsController/GET_show/assigns_contact.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/contact_points/a11425ca-6a47-4170-80b9-d6e9f3800a52.nt
+    uri: http://localhost:3030/contact_points/a11425ca-6a47-4170-80b9-d6e9f3800a52
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/ContactPointsController/GET_show/download/should_download_a_vcard_attachment.yml
+++ b/spec/fixtures/vcr_cassettes/ContactPointsController/GET_show/download/should_download_a_vcard_attachment.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/contact_points/a11425ca-6a47-4170-80b9-d6e9f3800a52.nt
+    uri: http://localhost:3030/contact_points/a11425ca-6a47-4170-80b9-d6e9f3800a52
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/ContactPointsController/GET_show/should_download_a_vcard_attachment.yml
+++ b/spec/fixtures/vcr_cassettes/ContactPointsController/GET_show/should_download_a_vcard_attachment.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/contact_points/a11425ca-6a47-4170-80b9-d6e9f3800a52.nt
+    uri: http://localhost:3030/contact_points/a11425ca-6a47-4170-80b9-d6e9f3800a52
     body:
       encoding: US-ASCII
       string: ''
@@ -49,6 +49,6 @@ http_interactions:
         <http://id.ukpds.org/17e446b1-04ef-4405-a772-0ee8d6e498bc> <http://id.ukpds.org/schema/postCode> "NR11 7BB" .
         <http://id.ukpds.org/17e446b1-04ef-4405-a772-0ee8d6e498bc> <http://id.ukpds.org/schema/addressLine1> "Mannington Hall" .
         <http://id.ukpds.org/17e446b1-04ef-4405-a772-0ee8d6e498bc> <http://id.ukpds.org/schema/addressLine2> "Norwich" .
-    http_version: 
+    http_version:
   recorded_at: Thu, 09 Feb 2017 12:55:25 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/ContactPointsController/GET_show/should_have_a_response_with_a_http_status_ok_200_.yml
+++ b/spec/fixtures/vcr_cassettes/ContactPointsController/GET_show/should_have_a_response_with_a_http_status_ok_200_.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/contact_points/a11425ca-6a47-4170-80b9-d6e9f3800a52.nt
+    uri: http://localhost:3030/contact_points/a11425ca-6a47-4170-80b9-d6e9f3800a52
     body:
       encoding: US-ASCII
       string: ''
@@ -49,6 +49,6 @@ http_interactions:
         <http://id.ukpds.org/17e446b1-04ef-4405-a772-0ee8d6e498bc> <http://id.ukpds.org/schema/postCode> "NR11 7BB" .
         <http://id.ukpds.org/17e446b1-04ef-4405-a772-0ee8d6e498bc> <http://id.ukpds.org/schema/addressLine1> "Mannington Hall" .
         <http://id.ukpds.org/17e446b1-04ef-4405-a772-0ee8d6e498bc> <http://id.ukpds.org/schema/addressLine2> "Norwich" .
-    http_version: 
+    http_version:
   recorded_at: Thu, 09 Feb 2017 12:55:25 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/HousesController/GET_current_members/assigns_house_and_people.yml
+++ b/spec/fixtures/vcr_cassettes/HousesController/GET_current_members/assigns_house_and_people.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/houses/c2d41b82-d4df-4f50-b0f9-f52b84a6a788/members/current.nt
+    uri: http://localhost:3030/houses/c2d41b82-d4df-4f50-b0f9-f52b84a6a788/members/current
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/HousesController/GET_current_members/renders_the_current_members_template.yml
+++ b/spec/fixtures/vcr_cassettes/HousesController/GET_current_members/renders_the_current_members_template.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/houses/c2d41b82-d4df-4f50-b0f9-f52b84a6a788/members/current.nt
+    uri: http://localhost:3030/houses/c2d41b82-d4df-4f50-b0f9-f52b84a6a788/members/current
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/HousesController/GET_current_members/should_have_a_response_with_http_status_ok_200_.yml
+++ b/spec/fixtures/vcr_cassettes/HousesController/GET_current_members/should_have_a_response_with_http_status_ok_200_.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/houses/c2d41b82-d4df-4f50-b0f9-f52b84a6a788/members/current.nt
+    uri: http://localhost:3030/houses/c2d41b82-d4df-4f50-b0f9-f52b84a6a788/members/current
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/HousesController/GET_current_members_letters/assigns_house_and_people.yml
+++ b/spec/fixtures/vcr_cassettes/HousesController/GET_current_members_letters/assigns_house_and_people.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/houses/c2d41b82-d4df-4f50-b0f9-f52b84a6a788/members/current/t.nt
+    uri: http://localhost:3030/houses/c2d41b82-d4df-4f50-b0f9-f52b84a6a788/members/current/t
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/HousesController/GET_current_members_letters/renders_the_current_members_letters_template.yml
+++ b/spec/fixtures/vcr_cassettes/HousesController/GET_current_members_letters/renders_the_current_members_letters_template.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/houses/c2d41b82-d4df-4f50-b0f9-f52b84a6a788/members/current/t.nt
+    uri: http://localhost:3030/houses/c2d41b82-d4df-4f50-b0f9-f52b84a6a788/members/current/t
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/HousesController/GET_current_members_letters/should_have_a_response_with_http_status_ok_200_.yml
+++ b/spec/fixtures/vcr_cassettes/HousesController/GET_current_members_letters/should_have_a_response_with_http_status_ok_200_.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/houses/c2d41b82-d4df-4f50-b0f9-f52b84a6a788/members/current/t.nt
+    uri: http://localhost:3030/houses/c2d41b82-d4df-4f50-b0f9-f52b84a6a788/members/current/t
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/HousesController/GET_current_parties/assigns_house_and_parties.yml
+++ b/spec/fixtures/vcr_cassettes/HousesController/GET_current_parties/assigns_house_and_parties.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/houses/c2d41b82-d4df-4f50-b0f9-f52b84a6a788/parties/current.nt
+    uri: http://localhost:3030/houses/c2d41b82-d4df-4f50-b0f9-f52b84a6a788/parties/current
     body:
       encoding: US-ASCII
       string: ''
@@ -69,6 +69,6 @@ http_interactions:
         <http://id.ukpds.org/0aed9061-7b9b-42f1-b3a8-0427460789d8> <http://id.ukpds.org/schema/partyName> "Green Party" .
         <http://id.ukpds.org/b24cf8e0-9552-4ea8-a102-134a395aaf18> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.ukpds.org/schema/Party> .
         <http://id.ukpds.org/b24cf8e0-9552-4ea8-a102-134a395aaf18> <http://id.ukpds.org/schema/partyName> "UK Independence Party" .
-    http_version: 
+    http_version:
   recorded_at: Wed, 08 Feb 2017 16:06:40 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/HousesController/GET_current_parties/renders_the_current_parties_template.yml
+++ b/spec/fixtures/vcr_cassettes/HousesController/GET_current_parties/renders_the_current_parties_template.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/houses/c2d41b82-d4df-4f50-b0f9-f52b84a6a788/parties/current.nt
+    uri: http://localhost:3030/houses/c2d41b82-d4df-4f50-b0f9-f52b84a6a788/parties/current
     body:
       encoding: US-ASCII
       string: ''
@@ -67,6 +67,6 @@ http_interactions:
         <http://id.ukpds.org/0aed9061-7b9b-42f1-b3a8-0427460789d8> <http://id.ukpds.org/schema/partyName> "Green Party" .
         <http://id.ukpds.org/b24cf8e0-9552-4ea8-a102-134a395aaf18> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.ukpds.org/schema/Party> .
         <http://id.ukpds.org/b24cf8e0-9552-4ea8-a102-134a395aaf18> <http://id.ukpds.org/schema/partyName> "UK Independence Party" .
-    http_version: 
+    http_version:
   recorded_at: Wed, 15 Feb 2017 10:58:10 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/HousesController/GET_current_parties/should_have_a_response_with_http_status_ok_200_.yml
+++ b/spec/fixtures/vcr_cassettes/HousesController/GET_current_parties/should_have_a_response_with_http_status_ok_200_.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/houses/c2d41b82-d4df-4f50-b0f9-f52b84a6a788/parties/current.nt
+    uri: http://localhost:3030/houses/c2d41b82-d4df-4f50-b0f9-f52b84a6a788/parties/current
     body:
       encoding: US-ASCII
       string: ''
@@ -69,6 +69,6 @@ http_interactions:
         <http://id.ukpds.org/0aed9061-7b9b-42f1-b3a8-0427460789d8> <http://id.ukpds.org/schema/partyName> "Green Party" .
         <http://id.ukpds.org/b24cf8e0-9552-4ea8-a102-134a395aaf18> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.ukpds.org/schema/Party> .
         <http://id.ukpds.org/b24cf8e0-9552-4ea8-a102-134a395aaf18> <http://id.ukpds.org/schema/partyName> "UK Independence Party" .
-    http_version: 
+    http_version:
   recorded_at: Wed, 08 Feb 2017 16:06:41 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/HousesController/GET_current_party_members/assigns_house_party_and_people.yml
+++ b/spec/fixtures/vcr_cassettes/HousesController/GET_current_party_members/assigns_house_party_and_people.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/houses/c2d41b82-d4df-4f50-b0f9-f52b84a6a788/parties/ab77ae5d-7559-4636-ac25-2a23fd961980/members/current.nt
+    uri: http://localhost:3030/houses/c2d41b82-d4df-4f50-b0f9-f52b84a6a788/parties/ab77ae5d-7559-4636-ac25-2a23fd961980/members/current
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/HousesController/GET_current_party_members/renders_the_current_party_members_template.yml
+++ b/spec/fixtures/vcr_cassettes/HousesController/GET_current_party_members/renders_the_current_party_members_template.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/houses/c2d41b82-d4df-4f50-b0f9-f52b84a6a788/parties/ab77ae5d-7559-4636-ac25-2a23fd961980/members/current.nt
+    uri: http://localhost:3030/houses/c2d41b82-d4df-4f50-b0f9-f52b84a6a788/parties/ab77ae5d-7559-4636-ac25-2a23fd961980/members/current
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/HousesController/GET_current_party_members/should_have_a_response_with_http_status_ok_200_.yml
+++ b/spec/fixtures/vcr_cassettes/HousesController/GET_current_party_members/should_have_a_response_with_http_status_ok_200_.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/houses/c2d41b82-d4df-4f50-b0f9-f52b84a6a788/parties/ab77ae5d-7559-4636-ac25-2a23fd961980/members/current.nt
+    uri: http://localhost:3030/houses/c2d41b82-d4df-4f50-b0f9-f52b84a6a788/parties/ab77ae5d-7559-4636-ac25-2a23fd961980/members/current
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/HousesController/GET_current_party_members_letters/assigns_house_party_and_people.yml
+++ b/spec/fixtures/vcr_cassettes/HousesController/GET_current_party_members_letters/assigns_house_party_and_people.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/houses/c2d41b82-d4df-4f50-b0f9-f52b84a6a788/parties/ab77ae5d-7559-4636-ac25-2a23fd961980/members/current/t.nt
+    uri: http://localhost:3030/houses/c2d41b82-d4df-4f50-b0f9-f52b84a6a788/parties/ab77ae5d-7559-4636-ac25-2a23fd961980/members/current/t
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/HousesController/GET_current_party_members_letters/renders_the_current_party_members_letters_template.yml
+++ b/spec/fixtures/vcr_cassettes/HousesController/GET_current_party_members_letters/renders_the_current_party_members_letters_template.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/houses/c2d41b82-d4df-4f50-b0f9-f52b84a6a788/parties/ab77ae5d-7559-4636-ac25-2a23fd961980/members/current/t.nt
+    uri: http://localhost:3030/houses/c2d41b82-d4df-4f50-b0f9-f52b84a6a788/parties/ab77ae5d-7559-4636-ac25-2a23fd961980/members/current/t
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/HousesController/GET_current_party_members_letters/should_have_a_response_with_http_status_ok_200_.yml
+++ b/spec/fixtures/vcr_cassettes/HousesController/GET_current_party_members_letters/should_have_a_response_with_http_status_ok_200_.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/houses/c2d41b82-d4df-4f50-b0f9-f52b84a6a788/parties/ab77ae5d-7559-4636-ac25-2a23fd961980/members/current/t.nt
+    uri: http://localhost:3030/houses/c2d41b82-d4df-4f50-b0f9-f52b84a6a788/parties/ab77ae5d-7559-4636-ac25-2a23fd961980/members/current/t
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/HousesController/GET_index/assigns_houses.yml
+++ b/spec/fixtures/vcr_cassettes/HousesController/GET_index/assigns_houses.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/houses.nt
+    uri: http://localhost:3030/houses
     body:
       encoding: US-ASCII
       string: ''
@@ -45,6 +45,6 @@ http_interactions:
         <http://id.ukpds.org/c2d41b82-d4df-4f50-b0f9-f52b84a6a788> <http://id.ukpds.org/schema/houseName> "House of Commons" .
         <http://id.ukpds.org/cdf477be-7bb3-4f19-bf63-b837795e37eb> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.ukpds.org/schema/House> .
         <http://id.ukpds.org/cdf477be-7bb3-4f19-bf63-b837795e37eb> <http://id.ukpds.org/schema/houseName> "House of Lords" .
-    http_version: 
+    http_version:
   recorded_at: Wed, 08 Feb 2017 15:21:57 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/HousesController/GET_index/renders_the_index_template.yml
+++ b/spec/fixtures/vcr_cassettes/HousesController/GET_index/renders_the_index_template.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/houses.nt
+    uri: http://localhost:3030/houses
     body:
       encoding: US-ASCII
       string: ''
@@ -45,6 +45,6 @@ http_interactions:
         <http://id.ukpds.org/c2d41b82-d4df-4f50-b0f9-f52b84a6a788> <http://id.ukpds.org/schema/houseName> "House of Commons" .
         <http://id.ukpds.org/cdf477be-7bb3-4f19-bf63-b837795e37eb> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.ukpds.org/schema/House> .
         <http://id.ukpds.org/cdf477be-7bb3-4f19-bf63-b837795e37eb> <http://id.ukpds.org/schema/houseName> "House of Lords" .
-    http_version: 
+    http_version:
   recorded_at: Wed, 08 Feb 2017 15:21:57 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/HousesController/GET_index/should_have_a_response_with_http_status_ok_200_.yml
+++ b/spec/fixtures/vcr_cassettes/HousesController/GET_index/should_have_a_response_with_http_status_ok_200_.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/houses.nt
+    uri: http://localhost:3030/houses
     body:
       encoding: US-ASCII
       string: ''
@@ -45,6 +45,6 @@ http_interactions:
         <http://id.ukpds.org/c2d41b82-d4df-4f50-b0f9-f52b84a6a788> <http://id.ukpds.org/schema/houseName> "House of Commons" .
         <http://id.ukpds.org/cdf477be-7bb3-4f19-bf63-b837795e37eb> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.ukpds.org/schema/House> .
         <http://id.ukpds.org/cdf477be-7bb3-4f19-bf63-b837795e37eb> <http://id.ukpds.org/schema/houseName> "House of Lords" .
-    http_version: 
+    http_version:
   recorded_at: Wed, 08 Feb 2017 15:21:57 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/HousesController/GET_lookup/redirects_to_houses/_id.yml
+++ b/spec/fixtures/vcr_cassettes/HousesController/GET_lookup/redirects_to_houses/_id.yml
@@ -1,0 +1,41 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:3030/houses/lookup?id=1&source=mnisId
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - localhost:3030
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Cache-Control:
+      - no-cache
+      X-Request-Id:
+      - 15beefa9-0683-4962-bf93-72217cd17a8d
+      X-Runtime:
+      - '0.023171'
+    body:
+      encoding: UTF-8
+      string: "<http://id.ukpds.org/9fc46fca-4a66-4fa9-a4af-d4c2bf1a2703> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+                      <http://id.ukpds.org/schema/House> .\n"
+    http_version:
+  recorded_at: Wed, 22 Feb 2017 16:25:33 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/HousesController/GET_lookup/should_have_a_response_with_http_status_redirect_302_.yml
+++ b/spec/fixtures/vcr_cassettes/HousesController/GET_lookup/should_have_a_response_with_http_status_redirect_302_.yml
@@ -1,0 +1,41 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:3030/houses/lookup?id=1&source=mnisId
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - localhost:3030
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Cache-Control:
+      - no-cache
+      X-Request-Id:
+      - 15beefa9-0683-4962-bf93-72217cd17a8d
+      X-Runtime:
+      - '0.023171'
+    body:
+      encoding: UTF-8
+      string: "<http://id.ukpds.org/9fc46fca-4a66-4fa9-a4af-d4c2bf1a2703> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+                      <http://id.ukpds.org/schema/House> .\n"
+    http_version:
+  recorded_at: Wed, 22 Feb 2017 16:25:33 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/HousesController/GET_lookup_by_letters/it_returns_a_single_result/redirects_to_houses/_id.yml
+++ b/spec/fixtures/vcr_cassettes/HousesController/GET_lookup_by_letters/it_returns_a_single_result/redirects_to_houses/_id.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/houses/commons.nt
+    uri: http://localhost:3030/houses/commons
     body:
       encoding: US-ASCII
       string: ''
@@ -43,6 +43,6 @@ http_interactions:
       string: |
         <http://id.ukpds.org/c2d41b82-d4df-4f50-b0f9-f52b84a6a788> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.ukpds.org/schema/House> .
         <http://id.ukpds.org/c2d41b82-d4df-4f50-b0f9-f52b84a6a788> <http://id.ukpds.org/schema/houseName> "House of Commons" .
-    http_version: 
+    http_version:
   recorded_at: Mon, 20 Feb 2017 17:17:26 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/HousesController/GET_lookup_by_letters/it_returns_a_single_result/should_have_a_response_with_http_status_redirect_302_.yml
+++ b/spec/fixtures/vcr_cassettes/HousesController/GET_lookup_by_letters/it_returns_a_single_result/should_have_a_response_with_http_status_redirect_302_.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/houses/commons.nt
+    uri: http://localhost:3030/houses/commons
     body:
       encoding: US-ASCII
       string: ''
@@ -43,6 +43,6 @@ http_interactions:
       string: |
         <http://id.ukpds.org/c2d41b82-d4df-4f50-b0f9-f52b84a6a788> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.ukpds.org/schema/House> .
         <http://id.ukpds.org/c2d41b82-d4df-4f50-b0f9-f52b84a6a788> <http://id.ukpds.org/schema/houseName> "House of Commons" .
-    http_version: 
+    http_version:
   recorded_at: Mon, 20 Feb 2017 17:17:26 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/HousesController/GET_lookup_by_letters/it_returns_multiple_results/redirects_to_houses/a-z/house.yml
+++ b/spec/fixtures/vcr_cassettes/HousesController/GET_lookup_by_letters/it_returns_multiple_results/redirects_to_houses/a-z/house.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/houses/house.nt
+    uri: http://localhost:3030/houses/house
     body:
       encoding: US-ASCII
       string: ''
@@ -45,6 +45,6 @@ http_interactions:
         <http://id.ukpds.org/c2d41b82-d4df-4f50-b0f9-f52b84a6a788> <http://id.ukpds.org/schema/houseName> "House of Commons" .
         <http://id.ukpds.org/cdf477be-7bb3-4f19-bf63-b837795e37eb> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.ukpds.org/schema/House> .
         <http://id.ukpds.org/cdf477be-7bb3-4f19-bf63-b837795e37eb> <http://id.ukpds.org/schema/houseName> "House of Lords" .
-    http_version: 
+    http_version:
   recorded_at: Mon, 20 Feb 2017 16:01:04 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/HousesController/GET_lookup_by_letters/it_returns_multiple_results/redirects_to_index.yml
+++ b/spec/fixtures/vcr_cassettes/HousesController/GET_lookup_by_letters/it_returns_multiple_results/redirects_to_index.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/houses/house.nt
+    uri: http://localhost:3030/houses/house
     body:
       encoding: US-ASCII
       string: ''
@@ -45,6 +45,6 @@ http_interactions:
         <http://id.ukpds.org/c2d41b82-d4df-4f50-b0f9-f52b84a6a788> <http://id.ukpds.org/schema/houseName> "House of Commons" .
         <http://id.ukpds.org/cdf477be-7bb3-4f19-bf63-b837795e37eb> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.ukpds.org/schema/House> .
         <http://id.ukpds.org/cdf477be-7bb3-4f19-bf63-b837795e37eb> <http://id.ukpds.org/schema/houseName> "House of Lords" .
-    http_version: 
+    http_version:
   recorded_at: Mon, 20 Feb 2017 16:03:00 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/HousesController/GET_lookup_by_letters/it_returns_multiple_results/should_have_a_response_with_http_status_redirect_302_.yml
+++ b/spec/fixtures/vcr_cassettes/HousesController/GET_lookup_by_letters/it_returns_multiple_results/should_have_a_response_with_http_status_redirect_302_.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/houses/house.nt
+    uri: http://localhost:3030/houses/house
     body:
       encoding: US-ASCII
       string: ''
@@ -45,6 +45,6 @@ http_interactions:
         <http://id.ukpds.org/c2d41b82-d4df-4f50-b0f9-f52b84a6a788> <http://id.ukpds.org/schema/houseName> "House of Commons" .
         <http://id.ukpds.org/cdf477be-7bb3-4f19-bf63-b837795e37eb> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.ukpds.org/schema/House> .
         <http://id.ukpds.org/cdf477be-7bb3-4f19-bf63-b837795e37eb> <http://id.ukpds.org/schema/houseName> "House of Lords" .
-    http_version: 
+    http_version:
   recorded_at: Mon, 20 Feb 2017 16:01:04 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/HousesController/GET_members/assigns_house_and_people.yml
+++ b/spec/fixtures/vcr_cassettes/HousesController/GET_members/assigns_house_and_people.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/houses/c2d41b82-d4df-4f50-b0f9-f52b84a6a788/members.nt
+    uri: http://localhost:3030/houses/c2d41b82-d4df-4f50-b0f9-f52b84a6a788/members
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/HousesController/GET_members/renders_the_members_template.yml
+++ b/spec/fixtures/vcr_cassettes/HousesController/GET_members/renders_the_members_template.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/houses/c2d41b82-d4df-4f50-b0f9-f52b84a6a788/members.nt
+    uri: http://localhost:3030/houses/c2d41b82-d4df-4f50-b0f9-f52b84a6a788/members
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/HousesController/GET_members/should_have_a_response_with_http_status_ok_200_.yml
+++ b/spec/fixtures/vcr_cassettes/HousesController/GET_members/should_have_a_response_with_http_status_ok_200_.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/houses/c2d41b82-d4df-4f50-b0f9-f52b84a6a788/members.nt
+    uri: http://localhost:3030/houses/c2d41b82-d4df-4f50-b0f9-f52b84a6a788/members
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/HousesController/GET_members_letters/assigns_house_and_people.yml
+++ b/spec/fixtures/vcr_cassettes/HousesController/GET_members_letters/assigns_house_and_people.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/houses/c2d41b82-d4df-4f50-b0f9-f52b84a6a788/members/t.nt
+    uri: http://localhost:3030/houses/c2d41b82-d4df-4f50-b0f9-f52b84a6a788/members/t
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/HousesController/GET_members_letters/renders_the_members_letters_template.yml
+++ b/spec/fixtures/vcr_cassettes/HousesController/GET_members_letters/renders_the_members_letters_template.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/houses/c2d41b82-d4df-4f50-b0f9-f52b84a6a788/members/t.nt
+    uri: http://localhost:3030/houses/c2d41b82-d4df-4f50-b0f9-f52b84a6a788/members/t
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/HousesController/GET_members_letters/should_have_a_response_with_http_status_ok_200_.yml
+++ b/spec/fixtures/vcr_cassettes/HousesController/GET_members_letters/should_have_a_response_with_http_status_ok_200_.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/houses/c2d41b82-d4df-4f50-b0f9-f52b84a6a788/members/t.nt
+    uri: http://localhost:3030/houses/c2d41b82-d4df-4f50-b0f9-f52b84a6a788/members/t
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/HousesController/GET_parties/assigns_house_and_parties.yml
+++ b/spec/fixtures/vcr_cassettes/HousesController/GET_parties/assigns_house_and_parties.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/houses/c2d41b82-d4df-4f50-b0f9-f52b84a6a788/parties.nt
+    uri: http://localhost:3030/houses/c2d41b82-d4df-4f50-b0f9-f52b84a6a788/parties
     body:
       encoding: US-ASCII
       string: ''
@@ -129,6 +129,6 @@ http_interactions:
         <http://id.ukpds.org/c3e4e2b8-0f09-41d2-8462-334774fb90b2> <http://id.ukpds.org/schema/partyName> "United Ulster Unionist Movement" .
         <http://id.ukpds.org/297349af-3c83-44ae-824a-bef16fb6a47a> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.ukpds.org/schema/Party> .
         <http://id.ukpds.org/297349af-3c83-44ae-824a-bef16fb6a47a> <http://id.ukpds.org/schema/partyName> "United Ulster Unionist Party" .
-    http_version: 
+    http_version:
   recorded_at: Wed, 08 Feb 2017 15:58:01 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/HousesController/GET_parties/renders_the_parties_template.yml
+++ b/spec/fixtures/vcr_cassettes/HousesController/GET_parties/renders_the_parties_template.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/houses/c2d41b82-d4df-4f50-b0f9-f52b84a6a788/parties.nt
+    uri: http://localhost:3030/houses/c2d41b82-d4df-4f50-b0f9-f52b84a6a788/parties
     body:
       encoding: US-ASCII
       string: ''
@@ -129,6 +129,6 @@ http_interactions:
         <http://id.ukpds.org/c3e4e2b8-0f09-41d2-8462-334774fb90b2> <http://id.ukpds.org/schema/partyName> "United Ulster Unionist Movement" .
         <http://id.ukpds.org/297349af-3c83-44ae-824a-bef16fb6a47a> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.ukpds.org/schema/Party> .
         <http://id.ukpds.org/297349af-3c83-44ae-824a-bef16fb6a47a> <http://id.ukpds.org/schema/partyName> "United Ulster Unionist Party" .
-    http_version: 
+    http_version:
   recorded_at: Wed, 08 Feb 2017 15:58:02 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/HousesController/GET_parties/should_have_a_response_with_http_status_ok_200_.yml
+++ b/spec/fixtures/vcr_cassettes/HousesController/GET_parties/should_have_a_response_with_http_status_ok_200_.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/houses/c2d41b82-d4df-4f50-b0f9-f52b84a6a788/parties.nt
+    uri: http://localhost:3030/houses/c2d41b82-d4df-4f50-b0f9-f52b84a6a788/parties
     body:
       encoding: US-ASCII
       string: ''
@@ -129,6 +129,6 @@ http_interactions:
         <http://id.ukpds.org/c3e4e2b8-0f09-41d2-8462-334774fb90b2> <http://id.ukpds.org/schema/partyName> "United Ulster Unionist Movement" .
         <http://id.ukpds.org/297349af-3c83-44ae-824a-bef16fb6a47a> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.ukpds.org/schema/Party> .
         <http://id.ukpds.org/297349af-3c83-44ae-824a-bef16fb6a47a> <http://id.ukpds.org/schema/partyName> "United Ulster Unionist Party" .
-    http_version: 
+    http_version:
   recorded_at: Wed, 08 Feb 2017 15:58:01 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/HousesController/GET_party/assigns_house_and_parties.yml
+++ b/spec/fixtures/vcr_cassettes/HousesController/GET_party/assigns_house_and_parties.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/houses/c2d41b82-d4df-4f50-b0f9-f52b84a6a788/parties/ab77ae5d-7559-4636-ac25-2a23fd961980.nt
+    uri: http://localhost:3030/houses/c2d41b82-d4df-4f50-b0f9-f52b84a6a788/parties/ab77ae5d-7559-4636-ac25-2a23fd961980
     body:
       encoding: US-ASCII
       string: ''
@@ -45,6 +45,6 @@ http_interactions:
         <http://id.ukpds.org/c2d41b82-d4df-4f50-b0f9-f52b84a6a788> <http://id.ukpds.org/schema/houseName> "House of Commons" .
         <http://id.ukpds.org/ab77ae5d-7559-4636-ac25-2a23fd961980> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.ukpds.org/schema/Party> .
         <http://id.ukpds.org/ab77ae5d-7559-4636-ac25-2a23fd961980> <http://id.ukpds.org/schema/partyName> "Conservative" .
-    http_version: 
+    http_version:
   recorded_at: Thu, 09 Feb 2017 11:06:28 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/HousesController/GET_party/renders_the_party_template.yml
+++ b/spec/fixtures/vcr_cassettes/HousesController/GET_party/renders_the_party_template.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/houses/c2d41b82-d4df-4f50-b0f9-f52b84a6a788/parties/ab77ae5d-7559-4636-ac25-2a23fd961980.nt
+    uri: http://localhost:3030/houses/c2d41b82-d4df-4f50-b0f9-f52b84a6a788/parties/ab77ae5d-7559-4636-ac25-2a23fd961980
     body:
       encoding: US-ASCII
       string: ''
@@ -45,6 +45,6 @@ http_interactions:
         <http://id.ukpds.org/c2d41b82-d4df-4f50-b0f9-f52b84a6a788> <http://id.ukpds.org/schema/houseName> "House of Commons" .
         <http://id.ukpds.org/ab77ae5d-7559-4636-ac25-2a23fd961980> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.ukpds.org/schema/Party> .
         <http://id.ukpds.org/ab77ae5d-7559-4636-ac25-2a23fd961980> <http://id.ukpds.org/schema/partyName> "Conservative" .
-    http_version: 
+    http_version:
   recorded_at: Thu, 09 Feb 2017 11:06:28 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/HousesController/GET_party/should_have_a_response_with_http_status_ok_200_.yml
+++ b/spec/fixtures/vcr_cassettes/HousesController/GET_party/should_have_a_response_with_http_status_ok_200_.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/houses/c2d41b82-d4df-4f50-b0f9-f52b84a6a788/parties/ab77ae5d-7559-4636-ac25-2a23fd961980.nt
+    uri: http://localhost:3030/houses/c2d41b82-d4df-4f50-b0f9-f52b84a6a788/parties/ab77ae5d-7559-4636-ac25-2a23fd961980
     body:
       encoding: US-ASCII
       string: ''
@@ -45,6 +45,6 @@ http_interactions:
         <http://id.ukpds.org/c2d41b82-d4df-4f50-b0f9-f52b84a6a788> <http://id.ukpds.org/schema/houseName> "House of Commons" .
         <http://id.ukpds.org/ab77ae5d-7559-4636-ac25-2a23fd961980> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.ukpds.org/schema/Party> .
         <http://id.ukpds.org/ab77ae5d-7559-4636-ac25-2a23fd961980> <http://id.ukpds.org/schema/partyName> "Conservative" .
-    http_version: 
+    http_version:
   recorded_at: Thu, 09 Feb 2017 11:06:28 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/HousesController/GET_party_members/assigns_house_party_and_people.yml
+++ b/spec/fixtures/vcr_cassettes/HousesController/GET_party_members/assigns_house_party_and_people.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/houses/c2d41b82-d4df-4f50-b0f9-f52b84a6a788/parties/ab77ae5d-7559-4636-ac25-2a23fd961980/members.nt
+    uri: http://localhost:3030/houses/c2d41b82-d4df-4f50-b0f9-f52b84a6a788/parties/ab77ae5d-7559-4636-ac25-2a23fd961980/members
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/HousesController/GET_party_members/renders_the_party_members_template.yml
+++ b/spec/fixtures/vcr_cassettes/HousesController/GET_party_members/renders_the_party_members_template.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/houses/c2d41b82-d4df-4f50-b0f9-f52b84a6a788/parties/ab77ae5d-7559-4636-ac25-2a23fd961980/members.nt
+    uri: http://localhost:3030/houses/c2d41b82-d4df-4f50-b0f9-f52b84a6a788/parties/ab77ae5d-7559-4636-ac25-2a23fd961980/members
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/HousesController/GET_party_members/should_have_a_response_with_http_status_ok_200_.yml
+++ b/spec/fixtures/vcr_cassettes/HousesController/GET_party_members/should_have_a_response_with_http_status_ok_200_.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/houses/c2d41b82-d4df-4f50-b0f9-f52b84a6a788/parties/ab77ae5d-7559-4636-ac25-2a23fd961980/members.nt
+    uri: http://localhost:3030/houses/c2d41b82-d4df-4f50-b0f9-f52b84a6a788/parties/ab77ae5d-7559-4636-ac25-2a23fd961980/members
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/HousesController/GET_party_members_letters/assigns_house_party_and_people.yml
+++ b/spec/fixtures/vcr_cassettes/HousesController/GET_party_members_letters/assigns_house_party_and_people.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/houses/c2d41b82-d4df-4f50-b0f9-f52b84a6a788/parties/ab77ae5d-7559-4636-ac25-2a23fd961980/members/t.nt
+    uri: http://localhost:3030/houses/c2d41b82-d4df-4f50-b0f9-f52b84a6a788/parties/ab77ae5d-7559-4636-ac25-2a23fd961980/members/t
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/HousesController/GET_party_members_letters/renders_the_party_members_letters_template.yml
+++ b/spec/fixtures/vcr_cassettes/HousesController/GET_party_members_letters/renders_the_party_members_letters_template.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/houses/c2d41b82-d4df-4f50-b0f9-f52b84a6a788/parties/ab77ae5d-7559-4636-ac25-2a23fd961980/members/t.nt
+    uri: http://localhost:3030/houses/c2d41b82-d4df-4f50-b0f9-f52b84a6a788/parties/ab77ae5d-7559-4636-ac25-2a23fd961980/members/t
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/HousesController/GET_party_members_letters/should_have_a_response_with_http_status_ok_200_.yml
+++ b/spec/fixtures/vcr_cassettes/HousesController/GET_party_members_letters/should_have_a_response_with_http_status_ok_200_.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/houses/c2d41b82-d4df-4f50-b0f9-f52b84a6a788/parties/ab77ae5d-7559-4636-ac25-2a23fd961980/members/t.nt
+    uri: http://localhost:3030/houses/c2d41b82-d4df-4f50-b0f9-f52b84a6a788/parties/ab77ae5d-7559-4636-ac25-2a23fd961980/members/t
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/HousesController/GET_show/assigns_house.yml
+++ b/spec/fixtures/vcr_cassettes/HousesController/GET_show/assigns_house.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/houses/c2d41b82-d4df-4f50-b0f9-f52b84a6a788.nt
+    uri: http://localhost:3030/houses/c2d41b82-d4df-4f50-b0f9-f52b84a6a788
     body:
       encoding: US-ASCII
       string: ''
@@ -43,6 +43,6 @@ http_interactions:
       string: |
         <http://id.ukpds.org/c2d41b82-d4df-4f50-b0f9-f52b84a6a788> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.ukpds.org/schema/House> .
         <http://id.ukpds.org/c2d41b82-d4df-4f50-b0f9-f52b84a6a788> <http://id.ukpds.org/schema/houseName> "House of Commons" .
-    http_version: 
+    http_version:
   recorded_at: Wed, 08 Feb 2017 15:26:01 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/HousesController/GET_show/renders_the_show_template.yml
+++ b/spec/fixtures/vcr_cassettes/HousesController/GET_show/renders_the_show_template.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/houses/c2d41b82-d4df-4f50-b0f9-f52b84a6a788.nt
+    uri: http://localhost:3030/houses/c2d41b82-d4df-4f50-b0f9-f52b84a6a788
     body:
       encoding: US-ASCII
       string: ''
@@ -43,6 +43,6 @@ http_interactions:
       string: |
         <http://id.ukpds.org/c2d41b82-d4df-4f50-b0f9-f52b84a6a788> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.ukpds.org/schema/House> .
         <http://id.ukpds.org/c2d41b82-d4df-4f50-b0f9-f52b84a6a788> <http://id.ukpds.org/schema/houseName> "House of Commons" .
-    http_version: 
+    http_version:
   recorded_at: Wed, 08 Feb 2017 15:26:01 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/HousesController/GET_show/should_have_a_response_with_http_status_ok_200_.yml
+++ b/spec/fixtures/vcr_cassettes/HousesController/GET_show/should_have_a_response_with_http_status_ok_200_.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/houses/c2d41b82-d4df-4f50-b0f9-f52b84a6a788.nt
+    uri: http://localhost:3030/houses/c2d41b82-d4df-4f50-b0f9-f52b84a6a788
     body:
       encoding: US-ASCII
       string: ''
@@ -43,6 +43,6 @@ http_interactions:
       string: |
         <http://id.ukpds.org/c2d41b82-d4df-4f50-b0f9-f52b84a6a788> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.ukpds.org/schema/House> .
         <http://id.ukpds.org/c2d41b82-d4df-4f50-b0f9-f52b84a6a788> <http://id.ukpds.org/schema/houseName> "House of Commons" .
-    http_version: 
+    http_version:
   recorded_at: Wed, 08 Feb 2017 15:26:01 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/HousesController/it_returns_a_single_result/redirects_to_houses/_id.yml
+++ b/spec/fixtures/vcr_cassettes/HousesController/it_returns_a_single_result/redirects_to_houses/_id.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/houses/commons.nt
+    uri: http://localhost:3030/houses/commons
     body:
       encoding: US-ASCII
       string: ''
@@ -43,6 +43,6 @@ http_interactions:
       string: |
         <http://id.ukpds.org/c2d41b82-d4df-4f50-b0f9-f52b84a6a788> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.ukpds.org/schema/House> .
         <http://id.ukpds.org/c2d41b82-d4df-4f50-b0f9-f52b84a6a788> <http://id.ukpds.org/schema/houseName> "House of Commons" .
-    http_version: 
+    http_version:
   recorded_at: Mon, 20 Feb 2017 16:01:05 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/HousesController/it_returns_a_single_result/should_have_a_response_with_http_status_redirect_302_.yml
+++ b/spec/fixtures/vcr_cassettes/HousesController/it_returns_a_single_result/should_have_a_response_with_http_status_redirect_302_.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/houses/commons.nt
+    uri: http://localhost:3030/houses/commons
     body:
       encoding: US-ASCII
       string: ''
@@ -43,6 +43,6 @@ http_interactions:
       string: |
         <http://id.ukpds.org/c2d41b82-d4df-4f50-b0f9-f52b84a6a788> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.ukpds.org/schema/House> .
         <http://id.ukpds.org/c2d41b82-d4df-4f50-b0f9-f52b84a6a788> <http://id.ukpds.org/schema/houseName> "House of Commons" .
-    http_version: 
+    http_version:
   recorded_at: Mon, 20 Feb 2017 16:01:05 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/PartiesController/GET_current/renders_the_current_template.yml
+++ b/spec/fixtures/vcr_cassettes/PartiesController/GET_current/renders_the_current_template.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/parties/current.nt
+    uri: http://localhost:3030/parties/current
     body:
       encoding: US-ASCII
       string: ''
@@ -67,6 +67,6 @@ http_interactions:
         <http://id.ukpds.org/5b6e2e81-d440-45f8-a03e-f7f161d0ad4e> <http://id.ukpds.org/schema/partyName> "Ulster Unionist Party" .
         <http://id.ukpds.org/b24cf8e0-9552-4ea8-a102-134a395aaf18> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.ukpds.org/schema/Party> .
         <http://id.ukpds.org/b24cf8e0-9552-4ea8-a102-134a395aaf18> <http://id.ukpds.org/schema/partyName> "UK Independence Party" .
-    http_version: 
+    http_version:
   recorded_at: Wed, 08 Feb 2017 17:06:53 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/PartiesController/GET_current/should_return_a_Parliament_Response_object.yml
+++ b/spec/fixtures/vcr_cassettes/PartiesController/GET_current/should_return_a_Parliament_Response_object.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/parties/current.nt
+    uri: http://localhost:3030/parties/current
     body:
       encoding: US-ASCII
       string: ''
@@ -67,6 +67,6 @@ http_interactions:
         <http://id.ukpds.org/5b6e2e81-d440-45f8-a03e-f7f161d0ad4e> <http://id.ukpds.org/schema/partyName> "Ulster Unionist Party" .
         <http://id.ukpds.org/b24cf8e0-9552-4ea8-a102-134a395aaf18> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.ukpds.org/schema/Party> .
         <http://id.ukpds.org/b24cf8e0-9552-4ea8-a102-134a395aaf18> <http://id.ukpds.org/schema/partyName> "UK Independence Party" .
-    http_version: 
+    http_version:
   recorded_at: Wed, 08 Feb 2017 17:06:53 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/PartiesController/GET_current/should_return_the_current_number_of_parties.yml
+++ b/spec/fixtures/vcr_cassettes/PartiesController/GET_current/should_return_the_current_number_of_parties.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/parties/current.nt
+    uri: http://localhost:3030/parties/current
     body:
       encoding: US-ASCII
       string: ''
@@ -67,6 +67,6 @@ http_interactions:
         <http://id.ukpds.org/5b6e2e81-d440-45f8-a03e-f7f161d0ad4e> <http://id.ukpds.org/schema/partyName> "Ulster Unionist Party" .
         <http://id.ukpds.org/b24cf8e0-9552-4ea8-a102-134a395aaf18> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.ukpds.org/schema/Party> .
         <http://id.ukpds.org/b24cf8e0-9552-4ea8-a102-134a395aaf18> <http://id.ukpds.org/schema/partyName> "UK Independence Party" .
-    http_version: 
+    http_version:
   recorded_at: Wed, 08 Feb 2017 17:06:53 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/PartiesController/GET_current_members/for_a_specific_party/assigns_people_and_checks_that_the_type_is_Person.yml
+++ b/spec/fixtures/vcr_cassettes/PartiesController/GET_current_members/for_a_specific_party/assigns_people_and_checks_that_the_type_is_Person.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/parties/7a048f56-0ddd-48b0-85bd-cf5dd9fa5427/members/current.nt
+    uri: http://localhost:3030/parties/7a048f56-0ddd-48b0-85bd-cf5dd9fa5427/members/current
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/PartiesController/GET_current_members/for_a_specific_party/passes_an_invalid_party_id_to_the_show_page.yml
+++ b/spec/fixtures/vcr_cassettes/PartiesController/GET_current_members/for_a_specific_party/passes_an_invalid_party_id_to_the_show_page.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/parties/7a048f56-0ddd-48b0-85bd-cf5dd9fa5427/members/current.nt
+    uri: http://localhost:3030/parties/7a048f56-0ddd-48b0-85bd-cf5dd9fa5427/members/current
     body:
       encoding: US-ASCII
       string: ''
@@ -68,7 +68,7 @@ http_interactions:
   recorded_at: Thu, 09 Feb 2017 15:12:54 GMT
 - request:
     method: get
-    uri: http://localhost:3030/parties/FAKE-PARTY-ID/members/current.nt
+    uri: http://localhost:3030/parties/FAKE-PARTY-ID/members/current
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/PartiesController/GET_current_members/for_a_specific_party/renders_the_current_members_template.yml
+++ b/spec/fixtures/vcr_cassettes/PartiesController/GET_current_members/for_a_specific_party/renders_the_current_members_template.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/parties/7a048f56-0ddd-48b0-85bd-cf5dd9fa5427/members/current.nt
+    uri: http://localhost:3030/parties/7a048f56-0ddd-48b0-85bd-cf5dd9fa5427/members/current
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/PartiesController/GET_current_members/for_a_specific_party/renders_the_current_template.yml
+++ b/spec/fixtures/vcr_cassettes/PartiesController/GET_current_members/for_a_specific_party/renders_the_current_template.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/parties/7a048f56-0ddd-48b0-85bd-cf5dd9fa5427/members/current.nt
+    uri: http://localhost:3030/parties/7a048f56-0ddd-48b0-85bd-cf5dd9fa5427/members/current
     body:
       encoding: US-ASCII
       string: ''
@@ -5275,6 +5275,6 @@ http_interactions:
         <http://id.ukpds.org/7ee4538a-66e0-4bcd-a88c-bf1482473c63> <http://id.ukpds.org/schema/partyMemberHasPartyMembership> <http://id.ukpds.org/6f902784-d359-483c-aa45-72139a1b4869> .
         <http://id.ukpds.org/6f902784-d359-483c-aa45-72139a1b4869> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.ukpds.org/schema/PartyMembership> .
         <http://id.ukpds.org/6f902784-d359-483c-aa45-72139a1b4869> <http://id.ukpds.org/schema/partyMembershipStartDate> "2000-05-05"^^<http://www.w3.org/2001/XMLSchema#date> .
-    http_version: 
+    http_version:
   recorded_at: Wed, 15 Feb 2017 10:58:42 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/PartiesController/GET_current_members/for_a_specific_party/should_return_a_Parliament_Response.yml
+++ b/spec/fixtures/vcr_cassettes/PartiesController/GET_current_members/for_a_specific_party/should_return_a_Parliament_Response.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/parties/7a048f56-0ddd-48b0-85bd-cf5dd9fa5427/members/current.nt
+    uri: http://localhost:3030/parties/7a048f56-0ddd-48b0-85bd-cf5dd9fa5427/members/current
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/PartiesController/GET_current_members_letters/current_members_for_a_specific_party_with_a_specific_letter/assigns_party_and_checks_that_the_type_is_Party.yml
+++ b/spec/fixtures/vcr_cassettes/PartiesController/GET_current_members_letters/current_members_for_a_specific_party_with_a_specific_letter/assigns_party_and_checks_that_the_type_is_Party.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/parties/7a048f56-0ddd-48b0-85bd-cf5dd9fa5427/members/current/c.nt
+    uri: http://localhost:3030/parties/7a048f56-0ddd-48b0-85bd-cf5dd9fa5427/members/current/c
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/PartiesController/GET_current_members_letters/current_members_for_a_specific_party_with_a_specific_letter/assigns_people_and_checks_that_the_type_is_Person.yml
+++ b/spec/fixtures/vcr_cassettes/PartiesController/GET_current_members_letters/current_members_for_a_specific_party_with_a_specific_letter/assigns_people_and_checks_that_the_type_is_Person.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/parties/7a048f56-0ddd-48b0-85bd-cf5dd9fa5427/members/current/c.nt
+    uri: http://localhost:3030/parties/7a048f56-0ddd-48b0-85bd-cf5dd9fa5427/members/current/c
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/PartiesController/GET_current_members_letters/current_members_for_a_specific_party_with_a_specific_letter/renders_the_current_members_letters_template.yml
+++ b/spec/fixtures/vcr_cassettes/PartiesController/GET_current_members_letters/current_members_for_a_specific_party_with_a_specific_letter/renders_the_current_members_letters_template.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/parties/7a048f56-0ddd-48b0-85bd-cf5dd9fa5427/members/current/c.nt
+    uri: http://localhost:3030/parties/7a048f56-0ddd-48b0-85bd-cf5dd9fa5427/members/current/c
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/PartiesController/GET_index/assigns_parties.yml
+++ b/spec/fixtures/vcr_cassettes/PartiesController/GET_index/assigns_parties.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/parties.nt
+    uri: http://localhost:3030/parties
     body:
       encoding: US-ASCII
       string: ''
@@ -555,6 +555,6 @@ http_interactions:
         <http://id.ukpds.org/1c0bf06d-ff7d-45ce-ac21-76eb6edbec5a> <http://id.ukpds.org/schema/partyName> "LPBP" .
         <http://id.ukpds.org/d1dfd6ec-9a5e-48b6-8cdb-ee8b6e9010d3> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.ukpds.org/schema/Party> .
         <http://id.ukpds.org/d1dfd6ec-9a5e-48b6-8cdb-ee8b6e9010d3> <http://id.ukpds.org/schema/partyName> "SHH" .
-    http_version: 
+    http_version:
   recorded_at: Mon, 06 Feb 2017 12:11:29 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/PartiesController/GET_index/renders_the_index_template.yml
+++ b/spec/fixtures/vcr_cassettes/PartiesController/GET_index/renders_the_index_template.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/parties.nt
+    uri: http://localhost:3030/parties
     body:
       encoding: US-ASCII
       string: ''
@@ -555,6 +555,6 @@ http_interactions:
         <http://id.ukpds.org/1c0bf06d-ff7d-45ce-ac21-76eb6edbec5a> <http://id.ukpds.org/schema/partyName> "LPBP" .
         <http://id.ukpds.org/d1dfd6ec-9a5e-48b6-8cdb-ee8b6e9010d3> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.ukpds.org/schema/Party> .
         <http://id.ukpds.org/d1dfd6ec-9a5e-48b6-8cdb-ee8b6e9010d3> <http://id.ukpds.org/schema/partyName> "SHH" .
-    http_version: 
+    http_version:
   recorded_at: Mon, 06 Feb 2017 12:13:01 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/PartiesController/GET_index/should_have_a_response_with_http_status_ok_200_.yml
+++ b/spec/fixtures/vcr_cassettes/PartiesController/GET_index/should_have_a_response_with_http_status_ok_200_.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/parties.nt
+    uri: http://localhost:3030/parties
     body:
       encoding: US-ASCII
       string: ''
@@ -555,6 +555,6 @@ http_interactions:
         <http://id.ukpds.org/1c0bf06d-ff7d-45ce-ac21-76eb6edbec5a> <http://id.ukpds.org/schema/partyName> "LPBP" .
         <http://id.ukpds.org/d1dfd6ec-9a5e-48b6-8cdb-ee8b6e9010d3> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.ukpds.org/schema/Party> .
         <http://id.ukpds.org/d1dfd6ec-9a5e-48b6-8cdb-ee8b6e9010d3> <http://id.ukpds.org/schema/partyName> "SHH" .
-    http_version: 
+    http_version:
   recorded_at: Mon, 06 Feb 2017 12:06:37 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/PartiesController/GET_letters/parties_for_a_specific_letter/assigns_parties.yml
+++ b/spec/fixtures/vcr_cassettes/PartiesController/GET_letters/parties_for_a_specific_letter/assigns_parties.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/parties/h.nt
+    uri: http://localhost:3030/parties/h
     body:
       encoding: US-ASCII
       string: ''
@@ -45,6 +45,6 @@ http_interactions:
         <http://id.ukpds.org/de74edbd-7f73-4e54-bd63-4c3bd93c8b82> <http://id.ukpds.org/schema/partyName> "Humanity" .
         <http://id.ukpds.org/33152e23-181b-4e84-a0b6-46b5e78557f6> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.ukpds.org/schema/Party> .
         <http://id.ukpds.org/33152e23-181b-4e84-a0b6-46b5e78557f6> <http://id.ukpds.org/schema/partyName> "Hoi Polloi" .
-    http_version: 
+    http_version:
   recorded_at: Wed, 15 Feb 2017 12:23:53 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/PartiesController/GET_letters/parties_for_a_specific_letter/assigns_party_and_checks_that_the_correct_partyname_is_returned.yml
+++ b/spec/fixtures/vcr_cassettes/PartiesController/GET_letters/parties_for_a_specific_letter/assigns_party_and_checks_that_the_correct_partyname_is_returned.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/parties/h.nt
+    uri: http://localhost:3030/parties/h
     body:
       encoding: US-ASCII
       string: ''
@@ -45,6 +45,6 @@ http_interactions:
         <http://id.ukpds.org/de74edbd-7f73-4e54-bd63-4c3bd93c8b82> <http://id.ukpds.org/schema/partyName> "Humanity" .
         <http://id.ukpds.org/33152e23-181b-4e84-a0b6-46b5e78557f6> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.ukpds.org/schema/Party> .
         <http://id.ukpds.org/33152e23-181b-4e84-a0b6-46b5e78557f6> <http://id.ukpds.org/schema/partyName> "Hoi Polloi" .
-    http_version: 
+    http_version:
   recorded_at: Thu, 09 Feb 2017 11:51:46 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/PartiesController/GET_letters/parties_for_a_specific_letter/passes_an_invalid_letter_to_the_letters_page.yml
+++ b/spec/fixtures/vcr_cassettes/PartiesController/GET_letters/parties_for_a_specific_letter/passes_an_invalid_letter_to_the_letters_page.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/parties/h.nt
+    uri: http://localhost:3030/parties/h
     body:
       encoding: US-ASCII
       string: ''
@@ -45,6 +45,6 @@ http_interactions:
         <http://id.ukpds.org/de74edbd-7f73-4e54-bd63-4c3bd93c8b82> <http://id.ukpds.org/schema/partyName> "Humanity" .
         <http://id.ukpds.org/33152e23-181b-4e84-a0b6-46b5e78557f6> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.ukpds.org/schema/Party> .
         <http://id.ukpds.org/33152e23-181b-4e84-a0b6-46b5e78557f6> <http://id.ukpds.org/schema/partyName> "Hoi Polloi" .
-    http_version: 
+    http_version:
   recorded_at: Thu, 09 Feb 2017 11:51:46 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/PartiesController/GET_letters/parties_for_a_specific_letter/renders_the_letters_template.yml
+++ b/spec/fixtures/vcr_cassettes/PartiesController/GET_letters/parties_for_a_specific_letter/renders_the_letters_template.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/parties/h.nt
+    uri: http://localhost:3030/parties/h
     body:
       encoding: US-ASCII
       string: ''
@@ -45,6 +45,6 @@ http_interactions:
         <http://id.ukpds.org/de74edbd-7f73-4e54-bd63-4c3bd93c8b82> <http://id.ukpds.org/schema/partyName> "Humanity" .
         <http://id.ukpds.org/33152e23-181b-4e84-a0b6-46b5e78557f6> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.ukpds.org/schema/Party> .
         <http://id.ukpds.org/33152e23-181b-4e84-a0b6-46b5e78557f6> <http://id.ukpds.org/schema/partyName> "Hoi Polloi" .
-    http_version: 
+    http_version:
   recorded_at: Wed, 15 Feb 2017 11:00:56 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/PartiesController/GET_letters/parties_for_a_specific_letter/should_return_a_Grom_Node_object_as_a_party.yml
+++ b/spec/fixtures/vcr_cassettes/PartiesController/GET_letters/parties_for_a_specific_letter/should_return_a_Grom_Node_object_as_a_party.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/parties/h.nt
+    uri: http://localhost:3030/parties/h
     body:
       encoding: US-ASCII
       string: ''
@@ -45,6 +45,6 @@ http_interactions:
         <http://id.ukpds.org/de74edbd-7f73-4e54-bd63-4c3bd93c8b82> <http://id.ukpds.org/schema/partyName> "Humanity" .
         <http://id.ukpds.org/33152e23-181b-4e84-a0b6-46b5e78557f6> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.ukpds.org/schema/Party> .
         <http://id.ukpds.org/33152e23-181b-4e84-a0b6-46b5e78557f6> <http://id.ukpds.org/schema/partyName> "Hoi Polloi" .
-    http_version: 
+    http_version:
   recorded_at: Thu, 09 Feb 2017 11:51:46 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/PartiesController/GET_lookup/redirects_to_parties/_id.yml
+++ b/spec/fixtures/vcr_cassettes/PartiesController/GET_lookup/redirects_to_parties/_id.yml
@@ -1,0 +1,47 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:3030/parties/lookup?id=96&source=mnisId
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - localhost:3030
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/n-triples; charset=utf-8
+      Etag:
+      - W/"88bdd153a97c1eecdb9a12f1fd3d7d46"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - f905fd56-0c72-4d41-89b3-7acfde96d948
+      X-Runtime:
+      - '0.027973'
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: "<http://id.ukpds.org/9fc46fca-4a66-4fa9-a4af-d4c2bf1a2703> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <http://id.ukpds.org/schema/Party> .\n"
+    http_version: 
+  recorded_at: Wed, 22 Feb 2017 16:27:35 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/PartiesController/GET_lookup/redirects_to_people/_id.yml
+++ b/spec/fixtures/vcr_cassettes/PartiesController/GET_lookup/redirects_to_people/_id.yml
@@ -1,0 +1,47 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:3030/parties/lookup?id=96&source=mnisId
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - localhost:3030
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/n-triples; charset=utf-8
+      Etag:
+      - W/"88bdd153a97c1eecdb9a12f1fd3d7d46"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 3246995a-473c-40b8-a116-31575ee8a4ba
+      X-Runtime:
+      - '0.047193'
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: "<http://id.ukpds.org/9fc46fca-4a66-4fa9-a4af-d4c2bf1a2703> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <http://id.ukpds.org/schema/Party> .\n"
+    http_version: 
+  recorded_at: Wed, 22 Feb 2017 16:15:17 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/PartiesController/GET_lookup/should_have_a_response_with_http_status_redirect_302_.yml
+++ b/spec/fixtures/vcr_cassettes/PartiesController/GET_lookup/should_have_a_response_with_http_status_redirect_302_.yml
@@ -1,0 +1,47 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:3030/parties/lookup?id=96&source=mnisId
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - localhost:3030
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/n-triples; charset=utf-8
+      Etag:
+      - W/"88bdd153a97c1eecdb9a12f1fd3d7d46"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 4375fd46-28db-480e-83aa-2552446c8d25
+      X-Runtime:
+      - '0.043433'
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: "<http://id.ukpds.org/9fc46fca-4a66-4fa9-a4af-d4c2bf1a2703> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <http://id.ukpds.org/schema/Party> .\n"
+    http_version: 
+  recorded_at: Wed, 22 Feb 2017 16:15:17 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/PartiesController/GET_lookup_by_letters/it_returns_a_single_result/redirects_to_people/_id.yml
+++ b/spec/fixtures/vcr_cassettes/PartiesController/GET_lookup_by_letters/it_returns_a_single_result/redirects_to_people/_id.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/parties/guildford.nt
+    uri: http://localhost:3030/parties/guildford
     body:
       encoding: US-ASCII
       string: ''
@@ -43,6 +43,6 @@ http_interactions:
       string: |
         <http://id.ukpds.org/cd1f1624-a361-4e1f-92b7-9abf5378d953> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.ukpds.org/schema/Party> .
         <http://id.ukpds.org/cd1f1624-a361-4e1f-92b7-9abf5378d953> <http://id.ukpds.org/schema/partyName> "Guildford Greenbelt Group" .
-    http_version: 
+    http_version:
   recorded_at: Mon, 20 Feb 2017 17:17:05 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/PartiesController/GET_lookup_by_letters/it_returns_a_single_result/should_have_a_response_with_http_status_redirect_302_.yml
+++ b/spec/fixtures/vcr_cassettes/PartiesController/GET_lookup_by_letters/it_returns_a_single_result/should_have_a_response_with_http_status_redirect_302_.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/parties/guildford.nt
+    uri: http://localhost:3030/parties/guildford
     body:
       encoding: US-ASCII
       string: ''
@@ -43,6 +43,6 @@ http_interactions:
       string: |
         <http://id.ukpds.org/cd1f1624-a361-4e1f-92b7-9abf5378d953> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.ukpds.org/schema/Party> .
         <http://id.ukpds.org/cd1f1624-a361-4e1f-92b7-9abf5378d953> <http://id.ukpds.org/schema/partyName> "Guildford Greenbelt Group" .
-    http_version: 
+    http_version:
   recorded_at: Mon, 20 Feb 2017 17:17:04 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/PartiesController/GET_lookup_by_letters/it_returns_multiple_results/redirects_to_parties/a-z/labour.yml
+++ b/spec/fixtures/vcr_cassettes/PartiesController/GET_lookup_by_letters/it_returns_multiple_results/redirects_to_parties/a-z/labour.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/parties/labour.nt
+    uri: http://localhost:3030/parties/labour
     body:
       encoding: US-ASCII
       string: ''
@@ -57,6 +57,6 @@ http_interactions:
         <http://id.ukpds.org/7a048f56-0ddd-48b0-85bd-cf5dd9fa5427> <http://id.ukpds.org/schema/partyName> "Labour" .
         <http://id.ukpds.org/7f21628c-587f-4939-af50-b81d78d654e5> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.ukpds.org/schema/Party> .
         <http://id.ukpds.org/7f21628c-587f-4939-af50-b81d78d654e5> <http://id.ukpds.org/schema/partyName> "Scottish Labour Party" .
-    http_version: 
+    http_version:
   recorded_at: Mon, 20 Feb 2017 16:24:31 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/PartiesController/GET_lookup_by_letters/it_returns_multiple_results/should_have_a_response_with_http_status_redirect_302_.yml
+++ b/spec/fixtures/vcr_cassettes/PartiesController/GET_lookup_by_letters/it_returns_multiple_results/should_have_a_response_with_http_status_redirect_302_.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/parties/labour.nt
+    uri: http://localhost:3030/parties/labour
     body:
       encoding: US-ASCII
       string: ''
@@ -57,6 +57,6 @@ http_interactions:
         <http://id.ukpds.org/7a048f56-0ddd-48b0-85bd-cf5dd9fa5427> <http://id.ukpds.org/schema/partyName> "Labour" .
         <http://id.ukpds.org/7f21628c-587f-4939-af50-b81d78d654e5> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.ukpds.org/schema/Party> .
         <http://id.ukpds.org/7f21628c-587f-4939-af50-b81d78d654e5> <http://id.ukpds.org/schema/partyName> "Scottish Labour Party" .
-    http_version: 
+    http_version:
   recorded_at: Mon, 20 Feb 2017 16:24:31 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/PartiesController/GET_members/for_a_specific_party/assigns_people_and_checks_that_the_type_is_Person.yml
+++ b/spec/fixtures/vcr_cassettes/PartiesController/GET_members/for_a_specific_party/assigns_people_and_checks_that_the_type_is_Person.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/parties/7a048f56-0ddd-48b0-85bd-cf5dd9fa5427/members.nt
+    uri: http://localhost:3030/parties/7a048f56-0ddd-48b0-85bd-cf5dd9fa5427/members
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/PartiesController/GET_members/for_a_specific_party/passes_an_invalid_party_id_to_the_show_page.yml
+++ b/spec/fixtures/vcr_cassettes/PartiesController/GET_members/for_a_specific_party/passes_an_invalid_party_id_to_the_show_page.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/parties/7a048f56-0ddd-48b0-85bd-cf5dd9fa5427/members.nt
+    uri: http://localhost:3030/parties/7a048f56-0ddd-48b0-85bd-cf5dd9fa5427/members
     body:
       encoding: US-ASCII
       string: ''
@@ -66,7 +66,7 @@ http_interactions:
   recorded_at: Thu, 09 Feb 2017 15:12:49 GMT
 - request:
     method: get
-    uri: http://localhost:3030/parties/FAKE-PARTY-ID/members.nt
+    uri: http://localhost:3030/parties/FAKE-PARTY-ID/members
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/PartiesController/GET_members/for_a_specific_party/renders_the_current_template.yml
+++ b/spec/fixtures/vcr_cassettes/PartiesController/GET_members/for_a_specific_party/renders_the_current_template.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/parties/7a048f56-0ddd-48b0-85bd-cf5dd9fa5427/members.nt
+    uri: http://localhost:3030/parties/7a048f56-0ddd-48b0-85bd-cf5dd9fa5427/members
     body:
       encoding: US-ASCII
       string: ''
@@ -9296,6 +9296,6 @@ http_interactions:
         <http://id.ukpds.org/7ee4538a-66e0-4bcd-a88c-bf1482473c63> <http://id.ukpds.org/schema/partyMemberHasPartyMembership> <http://id.ukpds.org/6f902784-d359-483c-aa45-72139a1b4869> .
         <http://id.ukpds.org/6f902784-d359-483c-aa45-72139a1b4869> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.ukpds.org/schema/PartyMembership> .
         <http://id.ukpds.org/6f902784-d359-483c-aa45-72139a1b4869> <http://id.ukpds.org/schema/partyMembershipStartDate> "2000-05-05"^^<http://www.w3.org/2001/XMLSchema#date> .
-    http_version: 
+    http_version:
   recorded_at: Wed, 15 Feb 2017 10:58:43 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/PartiesController/GET_members/for_a_specific_party/renders_the_members_template.yml
+++ b/spec/fixtures/vcr_cassettes/PartiesController/GET_members/for_a_specific_party/renders_the_members_template.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/parties/7a048f56-0ddd-48b0-85bd-cf5dd9fa5427/members.nt
+    uri: http://localhost:3030/parties/7a048f56-0ddd-48b0-85bd-cf5dd9fa5427/members
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/PartiesController/GET_members/for_a_specific_party/should_return_a_Parliament_Response.yml
+++ b/spec/fixtures/vcr_cassettes/PartiesController/GET_members/for_a_specific_party/should_return_a_Parliament_Response.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/parties/7a048f56-0ddd-48b0-85bd-cf5dd9fa5427/members.nt
+    uri: http://localhost:3030/parties/7a048f56-0ddd-48b0-85bd-cf5dd9fa5427/members
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/PartiesController/GET_members_letters/members_for_a_specific_party_with_a_specific_letter/assigns_party_and_checks_that_the_type_is_Party.yml
+++ b/spec/fixtures/vcr_cassettes/PartiesController/GET_members_letters/members_for_a_specific_party_with_a_specific_letter/assigns_party_and_checks_that_the_type_is_Party.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/parties/7a048f56-0ddd-48b0-85bd-cf5dd9fa5427.nt
+    uri: http://localhost:3030/parties/7a048f56-0ddd-48b0-85bd-cf5dd9fa5427
     body:
       encoding: US-ASCII
       string: ''
@@ -47,7 +47,7 @@ http_interactions:
   recorded_at: Wed, 15 Feb 2017 09:39:35 GMT
 - request:
     method: get
-    uri: http://localhost:3030/parties/7a048f56-0ddd-48b0-85bd-cf5dd9fa5427/members/a.nt
+    uri: http://localhost:3030/parties/7a048f56-0ddd-48b0-85bd-cf5dd9fa5427/members/a
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/PartiesController/GET_members_letters/members_for_a_specific_party_with_a_specific_letter/assigns_people_and_checks_that_the_type_is_Person.yml
+++ b/spec/fixtures/vcr_cassettes/PartiesController/GET_members_letters/members_for_a_specific_party_with_a_specific_letter/assigns_people_and_checks_that_the_type_is_Person.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/parties/7a048f56-0ddd-48b0-85bd-cf5dd9fa5427/members/a.nt
+    uri: http://localhost:3030/parties/7a048f56-0ddd-48b0-85bd-cf5dd9fa5427/members/a
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/PartiesController/GET_members_letters/members_for_a_specific_party_with_a_specific_letter/renders_the_members_letters_template.yml
+++ b/spec/fixtures/vcr_cassettes/PartiesController/GET_members_letters/members_for_a_specific_party_with_a_specific_letter/renders_the_members_letters_template.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/parties/7a048f56-0ddd-48b0-85bd-cf5dd9fa5427/members/a.nt
+    uri: http://localhost:3030/parties/7a048f56-0ddd-48b0-85bd-cf5dd9fa5427/members/a
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/PartiesController/GET_members_letters/members_for_a_specific_party_with_a_specific_letter/should_return_a_Grom_Node_object_as_a_party.yml
+++ b/spec/fixtures/vcr_cassettes/PartiesController/GET_members_letters/members_for_a_specific_party_with_a_specific_letter/should_return_a_Grom_Node_object_as_a_party.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/parties/7a048f56-0ddd-48b0-85bd-cf5dd9fa5427/members/a.nt
+    uri: http://localhost:3030/parties/7a048f56-0ddd-48b0-85bd-cf5dd9fa5427/members/a
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/PartiesController/GET_show/for_a_valid_party_id/assigns_party_and_checks_that_the_partyName_is_contained_within_it.yml
+++ b/spec/fixtures/vcr_cassettes/PartiesController/GET_show/for_a_valid_party_id/assigns_party_and_checks_that_the_partyName_is_contained_within_it.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/parties/7a048f56-0ddd-48b0-85bd-cf5dd9fa5427.nt
+    uri: http://localhost:3030/parties/7a048f56-0ddd-48b0-85bd-cf5dd9fa5427
     body:
       encoding: US-ASCII
       string: ''
@@ -43,6 +43,6 @@ http_interactions:
       string: |
         <http://id.ukpds.org/7a048f56-0ddd-48b0-85bd-cf5dd9fa5427> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.ukpds.org/schema/Party> .
         <http://id.ukpds.org/7a048f56-0ddd-48b0-85bd-cf5dd9fa5427> <http://id.ukpds.org/schema/partyName> "Labour" .
-    http_version: 
+    http_version:
   recorded_at: Tue, 14 Feb 2017 16:52:22 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/PartiesController/GET_show/for_a_valid_party_id/renders_the_current_template.yml
+++ b/spec/fixtures/vcr_cassettes/PartiesController/GET_show/for_a_valid_party_id/renders_the_current_template.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/parties/7a048f56-0ddd-48b0-85bd-cf5dd9fa5427.nt
+    uri: http://localhost:3030/parties/7a048f56-0ddd-48b0-85bd-cf5dd9fa5427
     body:
       encoding: US-ASCII
       string: ''
@@ -43,6 +43,6 @@ http_interactions:
       string: |
         <http://id.ukpds.org/7a048f56-0ddd-48b0-85bd-cf5dd9fa5427> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.ukpds.org/schema/Party> .
         <http://id.ukpds.org/7a048f56-0ddd-48b0-85bd-cf5dd9fa5427> <http://id.ukpds.org/schema/partyName> "Labour" .
-    http_version: 
+    http_version:
   recorded_at: Wed, 15 Feb 2017 10:58:41 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/PartiesController/GET_show/for_a_valid_party_id/renders_the_show_template.yml
+++ b/spec/fixtures/vcr_cassettes/PartiesController/GET_show/for_a_valid_party_id/renders_the_show_template.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/parties/7a048f56-0ddd-48b0-85bd-cf5dd9fa5427.nt
+    uri: http://localhost:3030/parties/7a048f56-0ddd-48b0-85bd-cf5dd9fa5427
     body:
       encoding: US-ASCII
       string: ''
@@ -43,6 +43,6 @@ http_interactions:
       string: |
         <http://id.ukpds.org/7a048f56-0ddd-48b0-85bd-cf5dd9fa5427> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.ukpds.org/schema/Party> .
         <http://id.ukpds.org/7a048f56-0ddd-48b0-85bd-cf5dd9fa5427> <http://id.ukpds.org/schema/partyName> "Labour" .
-    http_version: 
+    http_version:
   recorded_at: Wed, 15 Feb 2017 11:00:56 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/PartiesController/GET_show/for_a_valid_party_id/response_should_return_ok.yml
+++ b/spec/fixtures/vcr_cassettes/PartiesController/GET_show/for_a_valid_party_id/response_should_return_ok.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/parties/7a048f56-0ddd-48b0-85bd-cf5dd9fa5427.nt
+    uri: http://localhost:3030/parties/7a048f56-0ddd-48b0-85bd-cf5dd9fa5427
     body:
       encoding: US-ASCII
       string: ''
@@ -43,6 +43,6 @@ http_interactions:
       string: |
         <http://id.ukpds.org/7a048f56-0ddd-48b0-85bd-cf5dd9fa5427> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.ukpds.org/schema/Party> .
         <http://id.ukpds.org/7a048f56-0ddd-48b0-85bd-cf5dd9fa5427> <http://id.ukpds.org/schema/partyName> "Labour" .
-    http_version: 
+    http_version:
   recorded_at: Tue, 14 Feb 2017 16:52:22 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/PartiesController/GET_show/for_a_valid_party_id/should_return_a_Grom_Node_object.yml
+++ b/spec/fixtures/vcr_cassettes/PartiesController/GET_show/for_a_valid_party_id/should_return_a_Grom_Node_object.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/parties/7a048f56-0ddd-48b0-85bd-cf5dd9fa5427.nt
+    uri: http://localhost:3030/parties/7a048f56-0ddd-48b0-85bd-cf5dd9fa5427
     body:
       encoding: US-ASCII
       string: ''
@@ -43,6 +43,6 @@ http_interactions:
       string: |
         <http://id.ukpds.org/7a048f56-0ddd-48b0-85bd-cf5dd9fa5427> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.ukpds.org/schema/Party> .
         <http://id.ukpds.org/7a048f56-0ddd-48b0-85bd-cf5dd9fa5427> <http://id.ukpds.org/schema/partyName> "Labour" .
-    http_version: 
+    http_version:
   recorded_at: Tue, 14 Feb 2017 16:52:23 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/PartiesController/it_returns_a_single_result/redirects_to_people/_id.yml
+++ b/spec/fixtures/vcr_cassettes/PartiesController/it_returns_a_single_result/redirects_to_people/_id.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/parties/guildford.nt
+    uri: http://localhost:3030/parties/guildford
     body:
       encoding: US-ASCII
       string: ''
@@ -43,6 +43,6 @@ http_interactions:
       string: |
         <http://id.ukpds.org/cd1f1624-a361-4e1f-92b7-9abf5378d953> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.ukpds.org/schema/Party> .
         <http://id.ukpds.org/cd1f1624-a361-4e1f-92b7-9abf5378d953> <http://id.ukpds.org/schema/partyName> "Guildford Greenbelt Group" .
-    http_version: 
+    http_version:
   recorded_at: Mon, 20 Feb 2017 16:24:32 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/PartiesController/it_returns_a_single_result/should_have_a_response_with_http_status_redirect_302_.yml
+++ b/spec/fixtures/vcr_cassettes/PartiesController/it_returns_a_single_result/should_have_a_response_with_http_status_redirect_302_.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/parties/guildford.nt
+    uri: http://localhost:3030/parties/guildford
     body:
       encoding: US-ASCII
       string: ''
@@ -43,6 +43,6 @@ http_interactions:
       string: |
         <http://id.ukpds.org/cd1f1624-a361-4e1f-92b7-9abf5378d953> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://id.ukpds.org/schema/Party> .
         <http://id.ukpds.org/cd1f1624-a361-4e1f-92b7-9abf5378d953> <http://id.ukpds.org/schema/partyName> "Guildford Greenbelt Group" .
-    http_version: 
+    http_version:
   recorded_at: Mon, 20 Feb 2017 16:24:32 GMT
 recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/PeopleController/GET_constituencies/assigns_person_and_constituencies.yml
+++ b/spec/fixtures/vcr_cassettes/PeopleController/GET_constituencies/assigns_person_and_constituencies.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff/constituencies.nt
+    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff/constituencies
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/PeopleController/GET_constituencies/renders_the_parties_template.yml
+++ b/spec/fixtures/vcr_cassettes/PeopleController/GET_constituencies/renders_the_parties_template.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff/constituencies.nt
+    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff/constituencies
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/PeopleController/GET_constituencies/should_have_a_response_with_http_status_ok_200_.yml
+++ b/spec/fixtures/vcr_cassettes/PeopleController/GET_constituencies/should_have_a_response_with_http_status_ok_200_.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff/constituencies.nt
+    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff/constituencies
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/PeopleController/GET_contact_points/assigns_person_and_contact_points.yml
+++ b/spec/fixtures/vcr_cassettes/PeopleController/GET_contact_points/assigns_person_and_contact_points.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/08a3dfac-652a-44d6-8a43-00bb13c60e47/contact_points.nt
+    uri: http://localhost:3030/people/08a3dfac-652a-44d6-8a43-00bb13c60e47/contact_points
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/PeopleController/GET_contact_points/renders_the_contact_points_template.yml
+++ b/spec/fixtures/vcr_cassettes/PeopleController/GET_contact_points/renders_the_contact_points_template.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/08a3dfac-652a-44d6-8a43-00bb13c60e47/contact_points.nt
+    uri: http://localhost:3030/people/08a3dfac-652a-44d6-8a43-00bb13c60e47/contact_points
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/PeopleController/GET_contact_points/should_have_a_response_with_http_status_ok_200_.yml
+++ b/spec/fixtures/vcr_cassettes/PeopleController/GET_contact_points/should_have_a_response_with_http_status_ok_200_.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/08a3dfac-652a-44d6-8a43-00bb13c60e47/contact_points.nt
+    uri: http://localhost:3030/people/08a3dfac-652a-44d6-8a43-00bb13c60e47/contact_points
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/PeopleController/GET_current_constituency/assigns_person_and_constituency.yml
+++ b/spec/fixtures/vcr_cassettes/PeopleController/GET_current_constituency/assigns_person_and_constituency.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/ff75cd0c-1a8b-49ab-8292-f00d153588e5/constituencies/current.nt
+    uri: http://localhost:3030/people/ff75cd0c-1a8b-49ab-8292-f00d153588e5/constituencies/current
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/PeopleController/GET_current_constituency/renders_the_current_constituency_template.yml
+++ b/spec/fixtures/vcr_cassettes/PeopleController/GET_current_constituency/renders_the_current_constituency_template.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/ff75cd0c-1a8b-49ab-8292-f00d153588e5/constituencies/current.nt
+    uri: http://localhost:3030/people/ff75cd0c-1a8b-49ab-8292-f00d153588e5/constituencies/current
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/PeopleController/GET_current_constituency/should_have_a_response_with_http_status_ok_200_.yml
+++ b/spec/fixtures/vcr_cassettes/PeopleController/GET_current_constituency/should_have_a_response_with_http_status_ok_200_.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/ff75cd0c-1a8b-49ab-8292-f00d153588e5/constituencies/current.nt
+    uri: http://localhost:3030/people/ff75cd0c-1a8b-49ab-8292-f00d153588e5/constituencies/current
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/PeopleController/GET_current_house/assigns_person_and_house.yml
+++ b/spec/fixtures/vcr_cassettes/PeopleController/GET_current_house/assigns_person_and_house.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/ff75cd0c-1a8b-49ab-8292-f00d153588e5/houses/current.nt
+    uri: http://localhost:3030/people/ff75cd0c-1a8b-49ab-8292-f00d153588e5/houses/current
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/PeopleController/GET_current_house/renders_the_current_house_template.yml
+++ b/spec/fixtures/vcr_cassettes/PeopleController/GET_current_house/renders_the_current_house_template.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/ff75cd0c-1a8b-49ab-8292-f00d153588e5/houses/current.nt
+    uri: http://localhost:3030/people/ff75cd0c-1a8b-49ab-8292-f00d153588e5/houses/current
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/PeopleController/GET_current_house/should_have_a_response_with_http_status_ok_200_.yml
+++ b/spec/fixtures/vcr_cassettes/PeopleController/GET_current_house/should_have_a_response_with_http_status_ok_200_.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/ff75cd0c-1a8b-49ab-8292-f00d153588e5/houses/current.nt
+    uri: http://localhost:3030/people/ff75cd0c-1a8b-49ab-8292-f00d153588e5/houses/current
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/PeopleController/GET_current_members/assigns_people.yml
+++ b/spec/fixtures/vcr_cassettes/PeopleController/GET_current_members/assigns_people.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/members/current.nt
+    uri: http://localhost:3030/people/members/current
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/PeopleController/GET_current_members/renders_the_current_members_template.yml
+++ b/spec/fixtures/vcr_cassettes/PeopleController/GET_current_members/renders_the_current_members_template.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/members/current.nt
+    uri: http://localhost:3030/people/members/current
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/PeopleController/GET_current_members/should_have_a_response_with_http_status_ok_200_.yml
+++ b/spec/fixtures/vcr_cassettes/PeopleController/GET_current_members/should_have_a_response_with_http_status_ok_200_.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/members/current.nt
+    uri: http://localhost:3030/people/members/current
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/PeopleController/GET_current_members_letters/assigns_people.yml
+++ b/spec/fixtures/vcr_cassettes/PeopleController/GET_current_members_letters/assigns_people.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/members/current/t.nt
+    uri: http://localhost:3030/people/members/current/t
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/PeopleController/GET_current_members_letters/renders_the_current_members_letters_template.yml
+++ b/spec/fixtures/vcr_cassettes/PeopleController/GET_current_members_letters/renders_the_current_members_letters_template.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/members/current/t.nt
+    uri: http://localhost:3030/people/members/current/t
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/PeopleController/GET_current_members_letters/should_have_a_response_with_http_status_ok_200_.yml
+++ b/spec/fixtures/vcr_cassettes/PeopleController/GET_current_members_letters/should_have_a_response_with_http_status_ok_200_.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/members/current/t.nt
+    uri: http://localhost:3030/people/members/current/t
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/PeopleController/GET_current_party/assigns_person_and_party.yml
+++ b/spec/fixtures/vcr_cassettes/PeopleController/GET_current_party/assigns_person_and_party.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff/parties/current.nt
+    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff/parties/current
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/PeopleController/GET_current_party/renders_the_current_party_template.yml
+++ b/spec/fixtures/vcr_cassettes/PeopleController/GET_current_party/renders_the_current_party_template.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff/parties/current.nt
+    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff/parties/current
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/PeopleController/GET_current_party/should_have_a_response_with_http_status_ok_200_.yml
+++ b/spec/fixtures/vcr_cassettes/PeopleController/GET_current_party/should_have_a_response_with_http_status_ok_200_.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff/parties/current.nt
+    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff/parties/current
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/PeopleController/GET_houses/assigns_person_and_houses.yml
+++ b/spec/fixtures/vcr_cassettes/PeopleController/GET_houses/assigns_person_and_houses.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/ff75cd0c-1a8b-49ab-8292-f00d153588e5/houses.nt
+    uri: http://localhost:3030/people/ff75cd0c-1a8b-49ab-8292-f00d153588e5/houses
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/PeopleController/GET_houses/renders_the_parties_template.yml
+++ b/spec/fixtures/vcr_cassettes/PeopleController/GET_houses/renders_the_parties_template.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/ff75cd0c-1a8b-49ab-8292-f00d153588e5/houses.nt
+    uri: http://localhost:3030/people/ff75cd0c-1a8b-49ab-8292-f00d153588e5/houses
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/PeopleController/GET_houses/should_have_a_response_with_http_status_ok_200_.yml
+++ b/spec/fixtures/vcr_cassettes/PeopleController/GET_houses/should_have_a_response_with_http_status_ok_200_.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/ff75cd0c-1a8b-49ab-8292-f00d153588e5/houses.nt
+    uri: http://localhost:3030/people/ff75cd0c-1a8b-49ab-8292-f00d153588e5/houses
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/PeopleController/GET_index/assigns_people.yml
+++ b/spec/fixtures/vcr_cassettes/PeopleController/GET_index/assigns_people.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people.nt
+    uri: http://localhost:3030/people
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/PeopleController/GET_index/renders_the_index_template.yml
+++ b/spec/fixtures/vcr_cassettes/PeopleController/GET_index/renders_the_index_template.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people.nt
+    uri: http://localhost:3030/people
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/PeopleController/GET_index/should_have_a_response_with_http_status_ok_200_.yml
+++ b/spec/fixtures/vcr_cassettes/PeopleController/GET_index/should_have_a_response_with_http_status_ok_200_.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people.nt
+    uri: http://localhost:3030/people
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/PeopleController/GET_letters/assigns_people.yml
+++ b/spec/fixtures/vcr_cassettes/PeopleController/GET_letters/assigns_people.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/t.nt
+    uri: http://localhost:3030/people/t
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/PeopleController/GET_letters/renders_the_letters_template.yml
+++ b/spec/fixtures/vcr_cassettes/PeopleController/GET_letters/renders_the_letters_template.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/t.nt
+    uri: http://localhost:3030/people/t
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/PeopleController/GET_letters/should_have_a_response_with_http_status_ok_200_.yml
+++ b/spec/fixtures/vcr_cassettes/PeopleController/GET_letters/should_have_a_response_with_http_status_ok_200_.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/t.nt
+    uri: http://localhost:3030/people/t
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/PeopleController/GET_lookup/redirects_to_people/_id.yml
+++ b/spec/fixtures/vcr_cassettes/PeopleController/GET_lookup/redirects_to_people/_id.yml
@@ -1,0 +1,47 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:3030/people/lookup?id=3898&source=mnisId
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - localhost:3030
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/n-triples; charset=utf-8
+      Etag:
+      - W/"7ecd9bb2fa266203794866922f7da6e0"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 4b0f1002-80d0-45c9-817a-2d1aa717d3a0
+      X-Runtime:
+      - '0.023386'
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: "<http://id.ukpds.org/581ade57-3805-4a4a-82c9-8d622cb352a4> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <http://id.ukpds.org/schema/Person> .\n"
+    http_version: 
+  recorded_at: Wed, 22 Feb 2017 16:11:05 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/PeopleController/GET_lookup/should_have_a_response_with_http_status_redirect_302_.yml
+++ b/spec/fixtures/vcr_cassettes/PeopleController/GET_lookup/should_have_a_response_with_http_status_redirect_302_.yml
@@ -1,0 +1,47 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:3030/people/lookup?id=3898&source=mnisId
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - localhost:3030
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/n-triples; charset=utf-8
+      Etag:
+      - W/"7ecd9bb2fa266203794866922f7da6e0"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 18c35224-5db3-4866-b43d-cc9f269d5b28
+      X-Runtime:
+      - '0.022241'
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: "<http://id.ukpds.org/581ade57-3805-4a4a-82c9-8d622cb352a4> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>
+        <http://id.ukpds.org/schema/Person> .\n"
+    http_version: 
+  recorded_at: Wed, 22 Feb 2017 16:11:05 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/PeopleController/GET_lookup_by_letters/it_returns_a_single_result/redirects_to_people/_id.yml
+++ b/spec/fixtures/vcr_cassettes/PeopleController/GET_lookup_by_letters/it_returns_a_single_result/redirects_to_people/_id.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/creasy.nt
+    uri: http://localhost:3030/people/creasy
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/PeopleController/GET_lookup_by_letters/it_returns_a_single_result/should_have_a_response_with_http_status_redirect_302_.yml
+++ b/spec/fixtures/vcr_cassettes/PeopleController/GET_lookup_by_letters/it_returns_a_single_result/should_have_a_response_with_http_status_redirect_302_.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/creasy.nt
+    uri: http://localhost:3030/people/creasy
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/PeopleController/GET_lookup_by_letters/it_returns_multiple_results/redirects_to_people/a-z/cam.yml
+++ b/spec/fixtures/vcr_cassettes/PeopleController/GET_lookup_by_letters/it_returns_multiple_results/redirects_to_people/a-z/cam.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/cam.nt
+    uri: http://localhost:3030/people/cam
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/PeopleController/GET_lookup_by_letters/it_returns_multiple_results/should_have_a_response_with_http_status_redirect_302_.yml
+++ b/spec/fixtures/vcr_cassettes/PeopleController/GET_lookup_by_letters/it_returns_multiple_results/should_have_a_response_with_http_status_redirect_302_.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/cam.nt
+    uri: http://localhost:3030/people/cam
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/PeopleController/GET_members/assigns_people.yml
+++ b/spec/fixtures/vcr_cassettes/PeopleController/GET_members/assigns_people.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/members.nt
+    uri: http://localhost:3030/people/members
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/PeopleController/GET_members/renders_the_members_template.yml
+++ b/spec/fixtures/vcr_cassettes/PeopleController/GET_members/renders_the_members_template.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/members.nt
+    uri: http://localhost:3030/people/members
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/PeopleController/GET_members/should_have_a_response_with_http_status_ok_200_.yml
+++ b/spec/fixtures/vcr_cassettes/PeopleController/GET_members/should_have_a_response_with_http_status_ok_200_.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/members.nt
+    uri: http://localhost:3030/people/members
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/PeopleController/GET_members_letters/assigns_people.yml
+++ b/spec/fixtures/vcr_cassettes/PeopleController/GET_members_letters/assigns_people.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/members/t.nt
+    uri: http://localhost:3030/people/members/t
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/PeopleController/GET_members_letters/renders_the_members_letters_template.yml
+++ b/spec/fixtures/vcr_cassettes/PeopleController/GET_members_letters/renders_the_members_letters_template.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/members/t.nt
+    uri: http://localhost:3030/people/members/t
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/PeopleController/GET_members_letters/should_have_a_response_with_http_status_ok_200_.yml
+++ b/spec/fixtures/vcr_cassettes/PeopleController/GET_members_letters/should_have_a_response_with_http_status_ok_200_.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/members/t.nt
+    uri: http://localhost:3030/people/members/t
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/PeopleController/GET_parties/assigns_person_and_parties.yml
+++ b/spec/fixtures/vcr_cassettes/PeopleController/GET_parties/assigns_person_and_parties.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff/parties.nt
+    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff/parties
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/PeopleController/GET_parties/renders_the_parties_template.yml
+++ b/spec/fixtures/vcr_cassettes/PeopleController/GET_parties/renders_the_parties_template.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff/parties.nt
+    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff/parties
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/PeopleController/GET_parties/should_have_a_response_with_http_status_ok_200_.yml
+++ b/spec/fixtures/vcr_cassettes/PeopleController/GET_parties/should_have_a_response_with_http_status_ok_200_.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff/parties.nt
+    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff/parties
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/PeopleController/GET_show/assigns_person.yml
+++ b/spec/fixtures/vcr_cassettes/PeopleController/GET_show/assigns_person.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff.nt
+    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/PeopleController/GET_show/renders_the_show_template.yml
+++ b/spec/fixtures/vcr_cassettes/PeopleController/GET_show/renders_the_show_template.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff.nt
+    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/PeopleController/GET_show/should_have_a_response_with_http_status_ok_200_.yml
+++ b/spec/fixtures/vcr_cassettes/PeopleController/GET_show/should_have_a_response_with_http_status_ok_200_.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff.nt
+    uri: http://localhost:3030/people/626b57f9-6ef0-475a-ae12-40a44aca7eff
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/PeopleController/rescue_from_Parliament_NoContentError/raises_an_ActionController_RoutingError.yml
+++ b/spec/fixtures/vcr_cassettes/PeopleController/rescue_from_Parliament_NoContentError/raises_an_ActionController_RoutingError.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3030/people/a11425ca-6a47-4170-80b9-d6e9f3800a52.nt
+    uri: http://localhost:3030/people/a11425ca-6a47-4170-80b9-d6e9f3800a52
     body:
       encoding: US-ASCII
       string: ''
@@ -35,6 +35,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: ''
-    http_version: 
+    http_version:
   recorded_at: Mon, 20 Feb 2017 17:32:44 GMT
 recorded_with: VCR 3.0.3


### PR DESCRIPTION
- Added lookup methods to routing and controllers
- Tested lookup methods redirect correctly if resource found
- Removed .nt extension from all vcr cassettes
- Updated the version of parliament-ruby