### PR TITLE
[WEBSITE-1245] Added full stops to description below links on home page

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -271,10 +271,10 @@ en:
         title: "What's on our test website"
       members_info:
         title: 'Members Information'
-        current_mps: 'View all current members of the House of Commons'
-        current_lords: 'View all current members of the House of Lords'
-        current_constituencies: 'Find current MPs by the area they represent'
-        current_parties: 'Find current MPs and Lords by their party or group'
+        current_mps: 'View all current members of the House of Commons.'
+        current_lords: 'View all current members of the House of Lords.'
+        current_constituencies: 'Find current MPs by the area they represent.'
+        current_parties: 'Find current MPs and Lords by their party or group.'
       latest_members:
         blog: 'Read the latest Members service %{link}.'
         blog_link: 'blog post'


### PR DESCRIPTION
* Added full stops to text below the ‘MPs’, ‘Lords’, ‘Constituencies’ and ‘Parties and groups’ links