### PR TITLE
[WEBSITE-1249] Change 'Biography' title to 'Roles' on Lord Pages

### DIFF
--- a/app/views/people/show.html.haml
+++ b/app/views/people/show.html.haml
@@ -64,7 +64,7 @@
             = "#{link_to(@postcode_constituency.members.first.display_name, person_path(@postcode_constituency.members.first.graph_id))}.".html_safe
       - elsif @person.statuses[:house_membership_status].include?('Current MP')
         %h3= t('.check_mp', name: @person.display_name)
-        
+
         = render partial: 'postcodes/postcode_lookup', locals: { path: people_postcode_lookup_path }
 
       - if @person.statuses[:house_membership_status].include?('Current MP') || @person.statuses[:house_membership_status].include?('Member of the House of Lords')
@@ -93,7 +93,7 @@
 %section
   .container
     - if @house_incumbencies.present? || @seat_incumbencies.present?
-      %h2= t('.biography').capitalize
+      %h2= t('.roles').capitalize
       - if @house_incumbencies.present?
         %h3= "#{t('member').capitalize} #{t('of_the')} #{t('house_of_lords')}"
         %ol.list--pipe

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -99,7 +99,7 @@ en:
       contact: 'contact'
       membership_history: 'membership history'
       election_history: 'election history'
-      biography: 'biography'
+      roles: 'roles'
       check_mp: 'Check if %{name} is your MP'
       correct_mp: '%{name} is the MP for the postcode entered.'
       incorrect_mp: '%{name} is not the MP for the postcode entered.  Your MP is '


### PR DESCRIPTION
* Changed tag in config/locales/en.yml file from 'biography' to 'roles'
* Amended view to use 'roles' tag instead of 'biography'
* Changed title from 'Biography' to roles on Lord pages