### PR TITLE
[WEBSITE-1247] Homepage - Under ‘Follow our progress’ only have ‘our …

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -280,8 +280,8 @@ en:
         blog_link: 'blog post'
       follow_progress:
         title: 'Follow our progress'
-        blog: 'Follow all %{link}.'
-        blog_link: 'new website developments on our blog'
+        blog: 'Follow all new website developments on %{link}.'
+        blog_link: 'our blog'
   # meta information translations
   meta:
     index:


### PR DESCRIPTION
…blog’ as the link text

* Updated blog and blog_link tags in config/locales/en.yml