### PR TITLE
Initial state setup

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,3 +1,3 @@
 # Be sure to restart your server when you modify this file.
 
-Rails.application.config.session_store :cookie_store, key: '_MembersPrototype_session'
+Rails.application.config.session_store :cookie_store, key: '_beta_parliament_session', secure: Rails.env.production?

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -126,3 +126,7 @@ RSpec.configure do |config|
     allow(Pugin::BANDIERA_CLIENT).to receive(:get_features_for_group).and_return({})
   end
 end
+
+def session
+  last_request.env['rack.session']
+end


### PR DESCRIPTION
* Configures cookie session store and enabled 'secure' cookies in production
* Configured RSPEC so that you can access `session` variables within tests

### Context
This piece of work is preparation for remembering information from users such as postcodes entered etc.

Currently session data is stored for the browser session only.